### PR TITLE
chore: Add lurk shard test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,3 +10,11 @@ fail-fast = false
 slow-timeout = { period = "300s", terminate-after = 4 }
 # Retry failed tests once, marked flaky if test then passes
 retries = 1
+
+[test-groups]
+limited = { max-threads = 4 }
+very-limited = { max-threads = 1 }
+
+[[profile.ci.overrides]]
+filter = '(test(_shard_) | test(_e2e))'
+test-group = 'very-limited'

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -535,14 +535,14 @@ pub fn u64_iszero<F>() -> FuncE<F> {
 pub fn u64_equal<F: AbstractField>() -> FuncE<F> {
     func!(
         fn u64_equal(a, b): [1] {
-            let zero = 0;
-            let one = 1;
             let a: [8] = load(a);
             let b: [8] = load(b);
             let diff = sub(a, b);
             if diff {
+                let zero = 0;
                 return zero
             }
+            let one = 1;
             return one
         }
     )


### PR DESCRIPTION
Fixes #259

Also addresses the nit from https://github.com/argumentcomputer/loam/pull/260#discussion_r1735229332

This PR does not try to generate a `CryptoProof` from the `MachineProof` since the former is in a private module, and exposing it might expose too much as `pub` we might not want to expose yet. It's extra annoying since `tests/fib.rs` is technically a separate crate so it couldn't just be `pub(crate)`.

I've manually tested the conversion in the REPL, and indeed when there are multiple shards, all the shards have the same public values and the `CryptoProof` conversion works fine.