### PR TITLE
feat: Add explicit syntax for commitments

### DIFF
--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -442,10 +442,18 @@ test!(
 test!(test_big_num_to_comm, "(comm #0x0)", |_| ZPtr::comm(
     [F::zero(); 8]
 ));
+test!(test_comm_to_big_num, "(bignum #c0x0)", |_| ZPtr::big_num(
+    [F::zero(); 8]
+));
 test!(
     test_big_num_to_comm_to_big_num,
     "(bignum (comm #0x0))",
     |_| ZPtr::big_num([F::zero(); 8])
+);
+test!(
+    test_comm_to_big_num_to_comm,
+    "(comm (bignum #c0x0))",
+    |_| ZPtr::comm([F::zero(); 8])
 );
 test!(test_big_num_equal1, "(= #0x0 #0x1)", |z| z.intern_nil());
 test!(test_big_num_equal2, "(= #0x0 #0x0)", intern_t);

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -429,6 +429,7 @@ test!(
 
 // big num
 test!(test_raw_big_num, "#0x0", |_| ZPtr::big_num([F::zero(); 8]));
+test!(test_raw_comm, "#c0x0", |_| ZPtr::comm([F::zero(); 8]));
 test!(
     test_raw_big_num2,
     "#0x4b51f7ca76e9700190d753b328b34f3f59e0ad3c70c486645b5890068862f3",
@@ -437,6 +438,16 @@ test!(
         preimg.extend([F::zero(); 8]);
         preimg.extend(ZPtr::num(F::from_canonical_u32(123)).flatten());
         ZPtr::big_num(lurk_hasher().hash(&preimg).try_into().unwrap())
+    }
+);
+test!(
+    test_raw_comm2,
+    "#c0x4b51f7ca76e9700190d753b328b34f3f59e0ad3c70c486645b5890068862f3",
+    |_| {
+        let mut preimg = Vec::with_capacity(24);
+        preimg.extend([F::zero(); 8]);
+        preimg.extend(ZPtr::num(F::from_canonical_u32(123)).flatten());
+        ZPtr::comm(lurk_hasher().hash(&preimg).try_into().unwrap())
     }
 );
 test!(test_big_num_to_comm, "(comm #0x0)", |_| ZPtr::comm(

--- a/src/lurk/parser/syntax.rs
+++ b/src/lurk/parser/syntax.rs
@@ -289,14 +289,14 @@ pub fn parse_prefixed_hex_digest<F: Field>(
 pub fn parse_big_num<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Syntax<F>> {
     move |from: Span<'_>| {
         let (i, (pos, res)) = parse_prefixed_hex_digest("#0x", DIGEST_SIZE)(from)?;
-        return Ok((i, Syntax::BigNum(pos, res.try_into().unwrap())));
+        Ok((i, Syntax::BigNum(pos, res.try_into().unwrap())))
     }
 }
 
 pub fn parse_comm<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Syntax<F>> {
     move |from: Span<'_>| {
         let (i, (pos, res)) = parse_prefixed_hex_digest("#c0x", DIGEST_SIZE)(from)?;
-        return Ok((i, Syntax::Comm(pos, res.try_into().unwrap())));
+        Ok((i, Syntax::Comm(pos, res.try_into().unwrap())))
     }
 }
 

--- a/src/lurk/parser/syntax.rs
+++ b/src/lurk/parser/syntax.rs
@@ -256,14 +256,17 @@ pub fn parse_numeric<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Synt
     }
 }
 
-pub fn parse_big_num<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Syntax<F>> {
+pub fn parse_prefixed_hex_digest<F: Field>(
+    prefix: &'static str,
+    digest_size: usize,
+) -> impl Fn(Span<'_>) -> ParseResult<'_, F, (Pos, Vec<F>)> {
     move |from: Span<'_>| {
-        let (i, _) = tag("#0x")(from)?;
+        let (i, _) = tag(prefix)(from)?;
         let (i, digits) = base::parse_litbase_digits(base::LitBase::Hex)(i)?;
         let (i, be_bytes) = be_bytes_from_digits(base::LitBase::Hex, &digits, i)?;
         let mut num = BigUint::from_bytes_be(&be_bytes);
-        let mut res = Vec::with_capacity(DIGEST_SIZE); // This is stored in little-endian
-        for _ in 0..DIGEST_SIZE {
+        let mut res = Vec::with_capacity(digest_size); // This is stored in little-endian
+        for _ in 0..digest_size {
             let rem = &num % F::order();
             res.push(F::from_canonical_u32(rem.try_into().unwrap()));
             num /= F::order();
@@ -278,8 +281,22 @@ pub fn parse_big_num<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Synt
             )
         } else {
             let pos = Pos::from_upto(from, i);
-            Ok((i, Syntax::BigNum(pos, res.try_into().unwrap())))
+            Ok((i, (pos, res)))
         }
+    }
+}
+
+pub fn parse_big_num<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Syntax<F>> {
+    move |from: Span<'_>| {
+        let (i, (pos, res)) = parse_prefixed_hex_digest("#0x", DIGEST_SIZE)(from)?;
+        return Ok((i, Syntax::BigNum(pos, res.try_into().unwrap())));
+    }
+}
+
+pub fn parse_comm<F: Field>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, Syntax<F>> {
+    move |from: Span<'_>| {
+        let (i, (pos, res)) = parse_prefixed_hex_digest("#c0x", DIGEST_SIZE)(from)?;
+        return Ok((i, Syntax::Comm(pos, res.try_into().unwrap())));
     }
 }
 
@@ -432,6 +449,7 @@ pub fn parse_syntax<F: Field>(
                 parse_list(state.clone(), meta, create_unknown_packages),
             ),
             parse_numeric(),
+            parse_comm(),
             parse_big_num(),
             context(
                 "symbol",

--- a/src/lurk/syntax.rs
+++ b/src/lurk/syntax.rs
@@ -17,6 +17,8 @@ pub enum Syntax<F> {
     I64(Pos, bool, u64),
     /// A big numeric type stored in little-endian
     BigNum(Pos, [F; DIGEST_SIZE]),
+    /// A commitment hash digest stored in little-endian
+    Comm(Pos, [F; DIGEST_SIZE]),
     /// A hierarchical symbol: foo, foo.bar.baz or keyword :foo
     Symbol(Pos, SymbolRef),
     /// A string literal: "foobar", "foo\nbar"
@@ -39,6 +41,7 @@ impl<F> Syntax<F> {
             | Self::U64(pos, _)
             | Self::I64(pos, ..)
             | Self::BigNum(pos, _)
+            | Self::Comm(pos, _)
             | Self::Symbol(pos, _)
             | Self::String(pos, _)
             | Self::Char(pos, _)
@@ -56,6 +59,7 @@ impl<F: fmt::Display + PrimeField> fmt::Display for Syntax<F> {
             Self::U64(_, x) => write!(f, "{x}u64"),
             Self::I64(_, sign, x) => write!(f, "{}{x}i64", if *sign { "-" } else { "" }),
             Self::BigNum(_, c) => write!(f, "#{:#x}", field_elts_to_biguint(c)),
+            Self::Comm(_, c) => write!(f, "#c{:#x}", field_elts_to_biguint(c)),
             Self::Symbol(_, x) => write!(f, "{x}"),
             Self::String(_, x) => write!(f, "\"{}\"", x.escape_default()),
             Self::Char(_, x) => {


### PR DESCRIPTION
Works pretty much identically to bignum syntax with a different prefix. We can bikeshed the actual syntax later, this is for unblocking the micro-chain simulator work.