### PR TITLE
Lurk lib

### DIFF
--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -34,3 +34,13 @@
 
 ;; zip
 !(assert-eq '((a . 1) (b . 2) (c . 3)) (zip '(a b c) '(1 2 3)))
+
+;; sort
+!(assert-eq '(1 1 2 4 7) (sort '(7 1 4 1 2)))
+
+;; map
+!(assert-eq '(1 4 9 16) (map (lambda (x) (* x x)) '(1 2 3 4)))
+
+;; permute
+!(assert-eq '(d b c a e) (permute '(a b c d e) 123))
+!(assert-eq '(e d a c b) (permute '(a b c d e) 987))

--- a/lib/util.lurk
+++ b/lib/util.lurk
@@ -1,15 +1,15 @@
-!(def position (lambda (elt list)
-                 (letrec ((aux (lambda (list)
-                                 (if (eq (car list) elt)
+!(def position (lambda (elt l)
+                 (letrec ((aux (lambda (l)
+                                 (if (eq (car l) elt)
                                      0
-                                     (+ 1 (aux (cdr list)))))))
-                   (if list (aux list)))))
+                                     (+ 1 (aux (cdr l)))))))
+                   (if l (aux l)))))
 
-!(defrec nth (lambda (n list)
-               (if list
+!(defrec nth (lambda (n l)
+               (if l
                    (if (= n 0)
-                       (car list)
-                       (nth (- n 1) (cdr list))))))
+                       (car l)
+                       (nth (- n 1) (cdr l))))))
 
 
 !(defrec nth-cdr (lambda (n l)
@@ -17,7 +17,7 @@
                        l
                        (cdr (nth-cdr (- n 1) l)))))
 
-!(def nth (lambda (n list) (car (nth-cdr n list))))
+!(def nth (lambda (n l) (car (nth-cdr n l))))
 
 !(defrec apply (lambda (f args)
                  (if args
@@ -58,3 +58,26 @@
                                 (if b
                                     (cons (cons (car a) (car b)) (aux (cdr a) (cdr b))))))))
               (aux a b))))
+
+!(defrec sort (lambda (l)
+                (if (cdr l)
+                    (let ((sorted-cdr (sort (cdr l))))
+                      (if (< (car l) (car sorted-cdr))
+                          (cons (car l) sorted-cdr)
+                        (cons (car sorted-cdr)
+                              (sort (cons (car l)
+                                          (cdr sorted-cdr))))))
+                  l)))
+
+!(defrec map (lambda (f l)
+               (if l
+                   (cons (f (car l)) (map f (cdr l))))))
+
+!(def permute (lambda (l seed)
+                (let ((committed (map (lambda (elt)
+                                        (bignum (hide (bignum (commit seed))
+                                                      elt)))
+                                      l))
+                      (sorted (sort committed)))
+                  (map (lambda (c) (open c)) sorted))))
+

--- a/src/lurk/cli/tests/mod.rs
+++ b/src/lurk/cli/tests/mod.rs
@@ -30,3 +30,10 @@ fn test_meta_commands_with_proofs() {
     std::fs::remove_file("repl-test-protocol-proof").unwrap();
     std::fs::remove_file("repl-test-protocol").unwrap();
 }
+
+#[test]
+fn test_lib() {
+    set_config(Config::default());
+    let mut repl = Repl::new();
+    assert!(repl.load_file("lib/tests.lurk".into(), false).is_ok());
+}


### PR DESCRIPTION
This PR does the following:
- fix functions broken by #289 by renaming `list` to `l`
- add `sort`, `map`, and `permute` functions
- ensure `lib/tests.lurk` is included in test suite, so Lurk dev doesn't accidentally break the library