### PR TITLE
chore: Update for Sphinx v1.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "arc-swap"
@@ -318,9 +318,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "shlex",
 ]
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -505,9 +505,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "expect-test"
@@ -1905,10 +1905,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "plotters"
-version = "0.3.6"
+name = "plain"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1919,15 +1925,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -2211,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags",
  "errno",
@@ -2291,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.16"
+version = "2.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb7ac86243095b70a7920639507b71d51a63390d1ba26c4f60a552fbb914a37"
+checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
 dependencies = [
  "sdd",
 ]
@@ -2306,9 +2312,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
+checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
 
 [[package]]
 name = "sec1"
@@ -2332,18 +2338,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2352,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -2507,7 +2513,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "sphinx-core"
 version = "1.0.0"
-source = "git+https://github.com/argumentcomputer/sphinx.git?branch=dev#f51436fe14e6d029313546e8284cf6762f81f776"
+source = "git+https://github.com/argumentcomputer/sphinx.git?branch=forward_ports_44#0174a5ffc19d8265abbb534eaef48164fe867065"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -2547,6 +2553,7 @@ dependencies = [
  "p3-symmetric",
  "p3-uni-stark",
  "p3-util",
+ "plain",
  "rand",
  "rayon-scan",
  "rrs-lib",
@@ -2569,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "sphinx-derive"
 version = "1.0.0"
-source = "git+https://github.com/argumentcomputer/sphinx.git?branch=dev#f51436fe14e6d029313546e8284cf6762f81f776"
+source = "git+https://github.com/argumentcomputer/sphinx.git?branch=forward_ports_44#0174a5ffc19d8265abbb534eaef48164fe867065"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2593,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "sphinx-primitives"
 version = "1.0.0"
-source = "git+https://github.com/argumentcomputer/sphinx.git?branch=dev#f51436fe14e6d029313546e8284cf6762f81f776"
+source = "git+https://github.com/argumentcomputer/sphinx.git?branch=forward_ports_44#0174a5ffc19d8265abbb534eaef48164fe867065"
 dependencies = [
  "itertools 0.12.1",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ p3-poseidon2 = { git = "https://github.com/argumentcomputer/Plonky3.git", branch
 p3-symmetric = { git = "https://github.com/argumentcomputer/Plonky3.git", branch = "sp1" }
 p3-uni-stark = { git = "https://github.com/argumentcomputer/Plonky3.git", branch = "sp1" }
 p3-util = { git = "https://github.com/argumentcomputer/Plonky3.git", branch = "sp1" }
-sphinx-core = { git = "https://github.com/argumentcomputer/sphinx.git", branch = "dev"}
-sphinx-derive = { git = "https://github.com/argumentcomputer/sphinx.git", branch = "dev" }
+sphinx-core = { git = "https://github.com/argumentcomputer/sphinx.git", branch = "forward_ports_44"}
+sphinx-derive = { git = "https://github.com/argumentcomputer/sphinx.git", branch = "forward_ports_44" }
 anyhow = "1.0.72"
 ascent = { git = "https://github.com/argumentcomputer/ascent.git" }
 arc-swap = "1.7.1"

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -4,7 +4,7 @@ use p3_field::AbstractField;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use sphinx_core::{
     air::MachineAir,
-    stark::{LocalProver, StarkGenericConfig, StarkMachine},
+    stark::{DefaultProver, MachineProver, StarkGenericConfig, StarkMachine},
     utils::{BabyBearPoseidon2, SphinxCoreOpts},
 };
 use std::time::Duration;
@@ -46,11 +46,7 @@ fn build_lurk_expr(arg: usize) -> String {
 fn setup<H: Chipset<BabyBear>>(
     arg: usize,
     toplevel: &Toplevel<BabyBear, H>,
-) -> (
-    List<BabyBear>,
-    FuncChip<'_, BabyBear, H>,
-    QueryRecord<BabyBear>,
-) {
+) -> (List<BabyBear>, FuncChip<BabyBear, H>, QueryRecord<BabyBear>) {
     let code = build_lurk_expr(arg);
     let zstore = &mut lurk_zstore();
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
@@ -125,7 +121,10 @@ fn e2e(c: &mut Criterion) {
                 let mut challenger_p = machine.config().challenger();
                 let opts = SphinxCoreOpts::default();
                 let shard = Shard::new(&record);
-                machine.prove::<LocalProver<_, _>>(&pk, shard, &mut challenger_p, opts);
+                let prover = DefaultProver::new(machine);
+                prover
+                    .prove(&pk, vec![shard], &mut challenger_p, opts)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -4,7 +4,7 @@ use p3_field::AbstractField;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use sphinx_core::{
     air::MachineAir,
-    stark::{LocalProver, StarkGenericConfig, StarkMachine},
+    stark::{DefaultProver, MachineProver, StarkGenericConfig, StarkMachine},
     utils::{BabyBearPoseidon2, SphinxCoreOpts},
 };
 use std::time::Duration;
@@ -50,11 +50,7 @@ fn setup<'a, H: Chipset<BabyBear>>(
     a: &'a str,
     b: &'a str,
     toplevel: &'a Toplevel<BabyBear, H>,
-) -> (
-    List<BabyBear>,
-    FuncChip<'a, BabyBear, H>,
-    QueryRecord<BabyBear>,
-) {
+) -> (List<BabyBear>, FuncChip<BabyBear, H>, QueryRecord<BabyBear>) {
     let code = build_lurk_expr(a, b);
     let zstore = &mut lurk_zstore();
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
@@ -129,7 +125,10 @@ fn e2e(c: &mut Criterion) {
                 let mut challenger_p = machine.config().challenger();
                 let opts = SphinxCoreOpts::default();
                 let shard = Shard::new(&record);
-                machine.prove::<LocalProver<_, _>>(&pk, shard, &mut challenger_p, opts);
+                let prover = DefaultProver::new(machine);
+                prover
+                    .prove(&pk, vec![shard], &mut challenger_p, opts)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -4,7 +4,7 @@ use p3_field::AbstractField;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use sphinx_core::{
     air::MachineAir,
-    stark::{LocalProver, StarkGenericConfig, StarkMachine},
+    stark::{DefaultProver, MachineProver, StarkGenericConfig, StarkMachine},
     utils::{BabyBearPoseidon2, SphinxCoreOpts},
 };
 use std::time::Duration;
@@ -50,11 +50,7 @@ fn build_lurk_expr(n: usize) -> String {
 fn setup<H: Chipset<BabyBear>>(
     n: usize,
     toplevel: &Toplevel<BabyBear, H>,
-) -> (
-    List<BabyBear>,
-    FuncChip<'_, BabyBear, H>,
-    QueryRecord<BabyBear>,
-) {
+) -> (List<BabyBear>, FuncChip<BabyBear, H>, QueryRecord<BabyBear>) {
     let code = build_lurk_expr(n);
 
     let zstore = &mut lurk_zstore();
@@ -130,7 +126,10 @@ fn e2e(c: &mut Criterion) {
                 let mut challenger_p = machine.config().challenger();
                 let opts = SphinxCoreOpts::default();
                 let shard = Shard::new(&record);
-                machine.prove::<LocalProver<_, _>>(&pk, shard, &mut challenger_p, opts);
+                let prover = DefaultProver::new(machine);
+                prover
+                    .prove(&pk, vec![shard], &mut challenger_p, opts)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/src/air/debug.rs
+++ b/src/air/debug.rs
@@ -9,7 +9,6 @@ use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
 use p3_matrix::Matrix;
 use sphinx_core::air::MachineAir;
-use sphinx_core::stark::MachineRecord;
 use std::collections::BTreeMap;
 
 type LocalRowView<'a, F> = VerticalPair<RowMajorMatrixView<'a, F>, RowMajorMatrixView<'a, F>>;
@@ -118,14 +117,13 @@ impl<F: PrimeField32> TraceQueries<F> {
 /// Helper function to execute and test queries and constraints using `debug_constraints_collecting_queries`
 pub fn debug_chip_constraints_and_queries_with_sharding<F: PrimeField32, C: Chipset<F>>(
     record: &QueryRecord<F>,
-    chips: &[LairChip<'_, F, C>],
+    chips: &[LairChip<F, C>],
     config: Option<ShardingConfig>,
 ) {
-    let full_shard = Shard::new(record);
     let shards = if let Some(config) = config {
-        full_shard.shard(&config)
+        config.shard(record)
     } else {
-        vec![full_shard]
+        vec![Shard::new(&record.clone())]
     };
 
     let lookup_queries: Vec<_> = shards

--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -130,13 +130,13 @@ fn eval_depth<F: Field, AB>(
     out.extend(dep_depth.iter().cloned());
 }
 
-impl<'a, AB, H: Chipset<AB::F>> Air<AB> for FuncChip<'a, AB::F, H>
+impl<AB, H: Chipset<AB::F>> Air<AB> for FuncChip<AB::F, H>
 where
     AB: AirBuilder + LookupBuilder,
     <AB as AirBuilder>::Var: Debug,
 {
     fn eval(&self, builder: &mut AB) {
-        self.func.eval(builder, self.toplevel, self.layout_sizes)
+        self.func.eval(builder, &self.toplevel, self.layout_sizes)
     }
 }
 

--- a/src/lair/chipset.rs
+++ b/src/lair/chipset.rs
@@ -5,7 +5,7 @@ use crate::air::builder::{LookupBuilder, Record, RequireRecord};
 
 use super::execute::QueryRecord;
 
-pub trait Chipset<F>: Sync {
+pub trait Chipset<F>: Send + Sync + 'static + Clone {
     fn input_size(&self) -> usize;
 
     fn output_size(&self) -> usize;
@@ -45,6 +45,7 @@ pub trait Chipset<F>: Sync {
     ) -> Vec<AB::Expr>;
 }
 
+#[derive(Clone)]
 pub struct Nochip;
 
 impl<F> Chipset<F> for Nochip {

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use p3_field::{AbstractField, PrimeField32};
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use sphinx_core::stark::{Indexed, MachineRecord};
+use sphinx_core::{stark::MachineRecord, utils::SphinxCoreOpts};
 use std::ops::Range;
 
 use crate::{
@@ -79,14 +79,14 @@ pub struct QueryRecord<F: PrimeField32> {
 }
 
 #[derive(Default, Clone, Debug, Eq, PartialEq)]
-pub struct Shard<'a, F: PrimeField32> {
+pub struct Shard<F: PrimeField32> {
     pub(crate) index: u32,
     // TODO: remove this `Option` once Sphinx no longer requires `Default`
-    pub(crate) queries: Option<&'a QueryRecord<F>>,
+    pub(crate) queries: Option<QueryRecord<F>>,
     pub(crate) shard_config: ShardingConfig,
 }
 
-impl<'a, F: PrimeField32> Shard<'a, F> {
+impl<F: PrimeField32> Shard<F> {
     /// Creates a new initial shard from the given `QueryRecord`.
     ///
     /// # Note
@@ -94,17 +94,19 @@ impl<'a, F: PrimeField32> Shard<'a, F> {
     /// Make sure to call `.shard()` on a `Shard` created by `new` when generating
     /// the traces, otherwise you will only get the first shard's trace.
     #[inline]
-    pub fn new(queries: &'a QueryRecord<F>) -> Self {
+    pub fn new(queries: &QueryRecord<F>) -> Self {
         Shard {
             index: 0,
-            queries: queries.into(),
+            queries: Some(queries.clone()),
             shard_config: ShardingConfig::default(),
         }
     }
 
     #[inline]
     pub fn queries(&self) -> &QueryRecord<F> {
-        self.queries.expect("Missing query record reference")
+        self.queries
+            .as_ref()
+            .expect("Missing query record reference")
     }
 
     pub fn get_func_range(&self, func_index: usize) -> Range<usize> {
@@ -127,18 +129,9 @@ impl<'a, F: PrimeField32> Shard<'a, F> {
     }
 }
 
-impl<'a, F: PrimeField32> Indexed for Shard<'a, F> {
-    fn index(&self) -> u32 {
-        self.index
-    }
-}
-
-impl<'a, F: PrimeField32> MachineRecord for Shard<'a, F> {
-    type Config = ShardingConfig;
-
-    fn set_index(&mut self, index: u32) {
-        self.index = index
-    }
+impl<F: PrimeField32> MachineRecord for Shard<F> {
+    // type Config = ShardingConfig;
+    type Config = SphinxCoreOpts;
 
     fn stats(&self) -> HashMap<String, usize> {
         // TODO: use `IndexMap` instead so the original insertion order is kept
@@ -187,38 +180,6 @@ impl<'a, F: PrimeField32> MachineRecord for Shard<'a, F> {
         // just a no-op because `generate_dependencies` is a no-op
     }
 
-    fn shard(self, config: &Self::Config) -> Vec<Self> {
-        let queries = self.queries();
-        let shard_size = config.max_shard_size as usize;
-        let max_num_func_rows: usize = queries
-            .func_queries
-            .iter()
-            .map(|q| q.len())
-            .max()
-            .unwrap_or_default();
-        // TODO: This snippet or equivalent is needed for memory sharding
-        // let max_num_mem_rows: usize = queries
-        //     .mem_queries
-        //     .iter()
-        //     .map(|q| q.len())
-        //     .max()
-        //     .unwrap_or_default();
-        // let max_num_rows = max_num_func_rows.max(max_num_mem_rows);
-        let max_num_rows = max_num_func_rows;
-
-        let remainder = max_num_rows % shard_size;
-        let num_shards = max_num_rows / shard_size + if remainder > 0 { 1 } else { 0 };
-        let mut shards = Vec::with_capacity(num_shards);
-        for shard_index in 0..num_shards {
-            shards.push(Shard {
-                index: shard_index as u32,
-                queries: self.queries,
-                shard_config: *config,
-            });
-        }
-        shards
-    }
-
     fn public_values<F2: AbstractField>(&self) -> Vec<F2> {
         self.expect_public_values()
             .iter()
@@ -241,6 +202,39 @@ impl Default for ShardingConfig {
                 |s| s.parse::<u32>().unwrap_or(DEFAULT_SHARD_SIZE),
             ),
         }
+    }
+}
+
+impl ShardingConfig {
+    pub fn shard<F: PrimeField32>(&self, queries: &QueryRecord<F>) -> Vec<Shard<F>> {
+        let shard_size = self.max_shard_size as usize;
+        let max_num_func_rows: usize = queries
+            .func_queries
+            .iter()
+            .map(|q| q.len())
+            .max()
+            .unwrap_or_default();
+        // TODO: This snippet or equivalent is needed for memory sharding
+        // let max_num_mem_rows: usize = queries
+        //     .mem_queries
+        //     .iter()
+        //     .map(|q| q.len())
+        //     .max()
+        //     .unwrap_or_default();
+        // let max_num_rows = max_num_func_rows.max(max_num_mem_rows);
+        let max_num_rows = max_num_func_rows;
+
+        let remainder = max_num_rows % shard_size;
+        let num_shards = max_num_rows / shard_size + if remainder > 0 { 1 } else { 0 };
+        let mut shards = Vec::with_capacity(num_shards);
+        for shard_index in 0..num_shards {
+            shards.push(Shard {
+                index: shard_index as u32,
+                queries: Some(queries.clone()),
+                shard_config: *self,
+            });
+        }
+        shards
     }
 }
 

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -25,37 +25,37 @@ impl LayoutSizes {
     }
 }
 
-pub struct FuncChip<'a, F, H: Chipset<F>> {
-    pub(crate) func: &'a Func<F>,
-    pub(crate) toplevel: &'a Toplevel<F, H>,
+pub struct FuncChip<F, H: Chipset<F>> {
+    pub(crate) func: Func<F>,
+    pub(crate) toplevel: Toplevel<F, H>,
     pub(crate) layout_sizes: LayoutSizes,
 }
 
-impl<'a, F, H: Chipset<F>> FuncChip<'a, F, H> {
+impl<F: Clone, H: Chipset<F>> FuncChip<F, H> {
     #[inline]
-    pub fn from_name(name: &'static str, toplevel: &'a Toplevel<F, H>) -> Self {
+    pub fn from_name(name: &'static str, toplevel: &Toplevel<F, H>) -> Self {
         let func = toplevel.get_by_name(name);
         Self::from_func(func, toplevel)
     }
 
     #[inline]
-    pub fn from_index(idx: usize, toplevel: &'a Toplevel<F, H>) -> Self {
+    pub fn from_index(idx: usize, toplevel: &Toplevel<F, H>) -> Self {
         let func = toplevel.get_by_index(idx);
         Self::from_func(func, toplevel)
     }
 
     #[inline]
-    pub fn from_func(func: &'a Func<F>, toplevel: &'a Toplevel<F, H>) -> Self {
+    pub fn from_func(func: &Func<F>, toplevel: &Toplevel<F, H>) -> Self {
         let layout_sizes = func.compute_layout_sizes(toplevel);
         Self {
-            func,
-            toplevel,
+            func: func.clone(),         // FIXME
+            toplevel: toplevel.clone(), // FIXME
             layout_sizes,
         }
     }
 
     #[inline]
-    pub fn from_toplevel(toplevel: &'a Toplevel<F, H>) -> Vec<Self> {
+    pub fn from_toplevel(toplevel: &Toplevel<F, H>) -> Vec<Self> {
         toplevel
             .map
             .get_pairs()
@@ -71,18 +71,18 @@ impl<'a, F, H: Chipset<F>> FuncChip<'a, F, H> {
 
     #[inline]
     pub fn func(&self) -> &Func<F> {
-        self.func
+        &self.func
     }
 
     #[inline]
     pub fn toplevel(&self) -> &Toplevel<F, H> {
-        self.toplevel
+        &self.toplevel
     }
 }
 
-impl<'a, F: Sync, H: Chipset<F>> BaseAir<F> for FuncChip<'a, F, H> {
+impl<F: Sync, H: Chipset<F>> BaseAir<F> for FuncChip<F, H> {
     fn width(&self) -> usize {
-        self.width()
+        self.layout_sizes.total()
     }
 }
 

--- a/src/lair/lair_chip.rs
+++ b/src/lair/lair_chip.rs
@@ -19,8 +19,8 @@ use super::{
     relations::OuterCallRelation,
 };
 
-pub enum LairChip<'a, F, H: Chipset<F>> {
-    Func(FuncChip<'a, F, H>),
+pub enum LairChip<F, H: Chipset<F>> {
+    Func(FuncChip<F, H>),
     Mem(MemChip<F>),
     Bytes(BytesChip<F>),
     Entrypoint {
@@ -29,7 +29,7 @@ pub enum LairChip<'a, F, H: Chipset<F>> {
     },
 }
 
-impl<'a, F, H: Chipset<F>> LairChip<'a, F, H> {
+impl<F, H: Chipset<F>> LairChip<F, H> {
     #[inline]
     pub fn entrypoint(func: &Func<F>) -> Self {
         let partial = if func.partial { DEPTH_W } else { 0 };
@@ -41,17 +41,17 @@ impl<'a, F, H: Chipset<F>> LairChip<'a, F, H> {
     }
 }
 
-impl<'a, F: PrimeField32, H: Chipset<F>> WithEvents<'a> for LairChip<'_, F, H> {
-    type Events = &'a Shard<'a, F>;
+impl<'a, F: PrimeField32, H: Chipset<F>> WithEvents<'a> for LairChip<F, H> {
+    type Events = &'a Shard<F>;
 }
 
-impl<'a, F: PrimeField32, H: Chipset<F>> EventLens<LairChip<'a, F, H>> for Shard<'a, F> {
-    fn events(&self) -> <LairChip<'a, F, H> as WithEvents<'_>>::Events {
+impl<F: PrimeField32, H: Chipset<F>> EventLens<LairChip<F, H>> for Shard<F> {
+    fn events(&self) -> <LairChip<F, H> as WithEvents<'_>>::Events {
         self
     }
 }
 
-impl<'a, F: Field + Sync, H: Chipset<F>> BaseAir<F> for LairChip<'a, F, H> {
+impl<F: Field + Sync, H: Chipset<F>> BaseAir<F> for LairChip<F, H> {
     fn width(&self) -> usize {
         match self {
             Self::Func(func_chip) => func_chip.width(),
@@ -72,8 +72,8 @@ impl<F: AbstractField> MachineProgram<F> for LairMachineProgram {
     }
 }
 
-impl<'a, F: PrimeField32, H: Chipset<F>> MachineAir<F> for LairChip<'a, F, H> {
-    type Record = Shard<'a, F>;
+impl<F: PrimeField32, H: Chipset<F>> MachineAir<F> for LairChip<F, H> {
+    type Record = Shard<F>;
     type Program = LairMachineProgram;
 
     fn name(&self) -> String {
@@ -97,7 +97,7 @@ impl<'a, F: PrimeField32, H: Chipset<F>> MachineAir<F> for LairChip<'a, F, H> {
             Self::Mem(mem_chip) => mem_chip.generate_trace(shard.events()),
             Self::Bytes(bytes_chip) => {
                 // TODO: Shard the byte events differently?
-                if shard.index() == 0 {
+                if shard.events().index == 0 {
                     bytes_chip.generate_trace(&shard.events().queries().bytes)
                 } else {
                     bytes_chip.generate_trace(&Default::default())
@@ -147,7 +147,7 @@ impl<'a, F: PrimeField32, H: Chipset<F>> MachineAir<F> for LairChip<'a, F, H> {
     }
 }
 
-impl<'a, AB, H: Chipset<AB::F>> Air<AB> for LairChip<'a, AB::F, H>
+impl<AB, H: Chipset<AB::F>> Air<AB> for LairChip<AB::F, H>
 where
     AB: AirBuilderWithPublicValues + LookupBuilder + PairBuilder,
     <AB as AirBuilder>::Var: std::fmt::Debug,
@@ -187,9 +187,9 @@ where
     }
 }
 
-pub fn build_lair_chip_vector<'a, F: PrimeField32, H: Chipset<F>>(
-    entry_func_chip: &FuncChip<'a, F, H>,
-) -> Vec<LairChip<'a, F, H>> {
+pub fn build_lair_chip_vector<F: PrimeField32, H: Chipset<F>>(
+    entry_func_chip: &FuncChip<F, H>,
+) -> Vec<LairChip<F, H>> {
     let toplevel = &entry_func_chip.toplevel;
     let func = &entry_func_chip.func;
     let mut chip_vector = Vec::with_capacity(2 + toplevel.map.size() + MEM_TABLE_SIZES.len());
@@ -206,20 +206,19 @@ pub fn build_lair_chip_vector<'a, F: PrimeField32, H: Chipset<F>>(
 
 #[inline]
 pub fn build_chip_vector_from_lair_chips<
-    'a,
     F: PrimeField32,
     H: Chipset<F>,
-    I: IntoIterator<Item = LairChip<'a, F, H>>,
+    I: IntoIterator<Item = LairChip<F, H>>,
 >(
     lair_chips: I,
-) -> Vec<Chip<F, LairChip<'a, F, H>>> {
+) -> Vec<Chip<F, LairChip<F, H>>> {
     lair_chips.into_iter().map(Chip::new).collect()
 }
 
 #[inline]
-pub fn build_chip_vector<'a, F: PrimeField32, H: Chipset<F>>(
-    entry_func_chip: &FuncChip<'a, F, H>,
-) -> Vec<Chip<F, LairChip<'a, F, H>>> {
+pub fn build_chip_vector<F: PrimeField32, H: Chipset<F>>(
+    entry_func_chip: &FuncChip<F, H>,
+) -> Vec<Chip<F, LairChip<F, H>>> {
     build_chip_vector_from_lair_chips(build_lair_chip_vector(entry_func_chip))
 }
 
@@ -230,9 +229,10 @@ mod tests {
     use super::*;
 
     use p3_baby_bear::BabyBear;
+    use sphinx_core::stark::MachineProver;
     use sphinx_core::utils::BabyBearPoseidon2;
     use sphinx_core::{
-        stark::{LocalProver, StarkGenericConfig, StarkMachine},
+        stark::{DefaultProver, StarkGenericConfig, StarkMachine},
         utils::SphinxCoreOpts,
     };
 
@@ -260,10 +260,14 @@ mod tests {
         let mut challenger_v = machine.config().challenger();
         let shard = Shard::new(&queries);
 
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard.clone()], &mut machine.config().challenger());
         let opts = SphinxCoreOpts::default();
-        let proof = machine.prove::<LocalProver<_, _>>(&pk, shard, &mut challenger_p, opts);
-        machine
+        let prover = DefaultProver::new(machine);
+        let proof = prover
+            .prove(&pk, vec![shard], &mut challenger_p, opts)
+            .unwrap();
+        prover
+            .machine()
             .verify(&vk, &proof, &mut challenger_v)
             .expect("proof verifies");
     }

--- a/src/lair/memory.rs
+++ b/src/lair/memory.rs
@@ -27,7 +27,7 @@ impl<F: PrimeField32> MemChip<F> {
         }
     }
 
-    pub fn generate_trace(&self, shard: &Shard<'_, F>) -> RowMajorMatrix<F> {
+    pub fn generate_trace(&self, shard: &Shard<F>) -> RowMajorMatrix<F> {
         let record = &shard.queries().mem_queries;
         let mem_idx = mem_index_from_len(self.len);
         let mem = &record[mem_idx];

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -69,9 +69,9 @@ impl<'a, T> ColumnMutSlice<'a, T> {
     }
 }
 
-impl<'a, F: PrimeField32, H: Chipset<F>> FuncChip<'a, F, H> {
+impl<F: PrimeField32, H: Chipset<F>> FuncChip<F, H> {
     /// Per-row parallel trace generation
-    pub fn generate_trace(&self, shard: &Shard<'_, F>) -> RowMajorMatrix<F> {
+    pub fn generate_trace(&self, shard: &Shard<F>) -> RowMajorMatrix<F> {
         let func_queries = &shard.queries().func_queries()[self.func.index];
         let range = shard.get_func_range(self.func.index);
         let width = self.width();
@@ -125,7 +125,7 @@ impl<'a, F: PrimeField32, H: Chipset<F>> FuncChip<'a, F, H> {
                     slice,
                     queries,
                     requires,
-                    self.toplevel,
+                    &self.toplevel,
                     result.depth,
                     depth_requires,
                 );
@@ -436,7 +436,7 @@ mod tests {
     use p3_baby_bear::BabyBear as F;
     use p3_field::AbstractField;
     use sphinx_core::{
-        stark::{LocalProver, MachineRecord, StarkGenericConfig, StarkMachine},
+        stark::{DefaultProver, MachineProver, StarkGenericConfig, StarkMachine},
         utils::{BabyBearPoseidon2, SphinxCoreOpts},
     };
 
@@ -693,8 +693,7 @@ mod tests {
 
         let lair_chips = build_lair_chip_vector(&ack_chip);
 
-        let shard = Shard::new(&queries);
-        let shards = shard.clone().shard(&ShardingConfig::default());
+        let shards = ShardingConfig::default().shard(&queries);
         assert!(
             shards.len() > 1,
             "lair_shard_test must have more than one shard"
@@ -716,12 +715,15 @@ mod tests {
         let (pk, vk) = machine.setup(&LairMachineProgram);
         let mut challenger_p = machine.config().challenger();
         let mut challenger_v = machine.config().challenger();
-        let shard = Shard::new(&queries);
 
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, shards.clone(), &mut machine.config().challenger());
         let opts = SphinxCoreOpts::default();
-        let proof = machine.prove::<LocalProver<_, _>>(&pk, shard, &mut challenger_p, opts);
-        machine
+        let prover = DefaultProver::new(machine);
+        let proof = prover
+            .prove(&pk, shards, &mut challenger_p, opts)
+            .expect("proof generates");
+        prover
+            .machine()
             .verify(&vk, &proof, &mut challenger_v)
             .expect("proof verifies");
     }

--- a/src/lurk/big_num.rs
+++ b/src/lurk/big_num.rs
@@ -111,7 +111,7 @@ pub fn field_elts_to_biguint<F: PrimeField>(elts: &[F]) -> BigUint {
 mod test {
     use p3_baby_bear::BabyBear as F;
     use p3_field::AbstractField;
-    use sphinx_core::{stark::StarkMachine, utils::BabyBearPoseidon2};
+    use sphinx_core::{stark::{StarkGenericConfig, StarkMachine}, utils::BabyBearPoseidon2};
 
     use crate::{
         air::debug::debug_chip_constraints_and_queries_with_sharding,
@@ -177,6 +177,6 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 }

--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -12,7 +12,7 @@ use rustyline::{
     Completer, Editor, Helper, Highlighter, Hinter,
 };
 use sphinx_core::{
-    stark::{LocalProver, StarkGenericConfig, StarkMachine},
+    stark::{DefaultProver, MachineProver, StarkGenericConfig, StarkMachine},
     utils::{BabyBearPoseidon2, SphinxCoreOpts},
 };
 use std::io::Write;
@@ -21,7 +21,7 @@ use std::{fmt::Debug, marker::PhantomData};
 use crate::{
     lair::{
         chipset::Chipset,
-        execute::{DebugEntry, DebugEntryKind, QueryRecord, QueryResult, Shard},
+        execute::{DebugEntry, DebugEntryKind, QueryRecord, QueryResult, ShardingConfig},
         func_chip::FuncChip,
         lair_chip::{build_chip_vector, LairChip, LairMachineProgram},
         toplevel::Toplevel,
@@ -150,9 +150,7 @@ impl Repl<BabyBear, LurkChip> {
 }
 
 impl<H: Chipset<BabyBear>> Repl<BabyBear, H> {
-    pub(crate) fn stark_machine(
-        &self,
-    ) -> StarkMachine<BabyBearPoseidon2, LairChip<'_, BabyBear, H>> {
+    pub(crate) fn stark_machine(&self) -> StarkMachine<BabyBearPoseidon2, LairChip<BabyBear, H>> {
         let lurk_main_chip = FuncChip::from_index(self.lurk_main_idx, &self.toplevel);
         StarkMachine::new(
             BabyBearPoseidon2::new(),
@@ -178,6 +176,7 @@ impl<H: Chipset<BabyBear>> Repl<BabyBear, H> {
         let machine = self.stark_machine();
         let (pk, vk) = machine.setup(&LairMachineProgram);
         let challenger_p = &mut machine.config().challenger();
+        let prover = DefaultProver::new(machine);
         let must_prove = if !proof_path.exists() {
             true
         } else {
@@ -186,18 +185,22 @@ impl<H: Chipset<BabyBear>> Repl<BabyBear, H> {
                 let machine_proof = io_proof.into_machine_proof();
                 let challenger_v = &mut challenger_p.clone();
                 // force an overwrite if verification goes wrong
-                machine.verify(&vk, &machine_proof, challenger_v).is_err()
+                prover
+                    .machine()
+                    .verify(&vk, &machine_proof, challenger_v)
+                    .is_err()
             } else {
                 // force an overwrite if deserialization goes wrong
                 true
             }
         };
         if must_prove {
-            let challenger_v = &mut challenger_p.clone();
-            let shard = Shard::new(&self.queries);
             let opts = SphinxCoreOpts::default();
-            let machine_proof = machine.prove::<LocalProver<_, _>>(&pk, shard, challenger_p, opts);
-            machine
+            let challenger_v = &mut challenger_p.clone();
+            let sharded = ShardingConfig::default().shard(&self.queries);
+            let machine_proof = prover.prove(&pk, sharded, challenger_p, opts)?;
+            prover
+                .machine()
                 .verify(&vk, &machine_proof, challenger_v)
                 .expect("Proof verification failed");
             let crypto_proof: CryptoProof = machine_proof.into();

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -1,12 +1,15 @@
 use once_cell::sync::OnceCell;
 use p3_baby_bear::BabyBear as F;
 use p3_field::AbstractField;
-use sphinx_core::{stark::StarkMachine, utils::BabyBearPoseidon2};
+use sphinx_core::{
+    stark::{StarkGenericConfig, StarkMachine},
+    utils::BabyBearPoseidon2,
+};
 
 use crate::{
     air::debug::debug_chip_constraints_and_queries_with_sharding,
     lair::{
-        execute::{QueryRecord, Shard, ShardingConfig},
+        execute::{QueryRecord, ShardingConfig},
         func_chip::FuncChip,
         lair_chip::{
             build_chip_vector_from_lair_chips, build_lair_chip_vector, LairMachineProgram,
@@ -62,7 +65,7 @@ fn run_test(
 
     let lurk_main = FuncChip::from_name("lurk_main", toplevel);
     let result = toplevel
-        .execute(lurk_main.func, &input, &mut record, None)
+        .execute(&lurk_main.func, &input, &mut record, None)
         .unwrap();
 
     assert_eq!(result.as_ref(), &expected_cloj(zstore).flatten());
@@ -78,14 +81,14 @@ fn run_test(
     );
 
     // debug constraints with Sphinx
-    let full_shard = Shard::new(&record);
     let machine = StarkMachine::new(
         config,
         build_chip_vector_from_lair_chips(lair_chips),
         record.expect_public_values().len(),
     );
     let (pk, _) = machine.setup(&LairMachineProgram);
-    machine.debug_constraints(&pk, full_shard);
+    let sharded = ShardingConfig::default().shard(&record);
+    machine.debug_constraints(&pk, sharded, &mut machine.config().challenger());
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/lurk/poseidon.rs
+++ b/src/lurk/poseidon.rs
@@ -38,7 +38,8 @@ impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> PoseidonChipset<C, WIDTH> {
     }
 }
 
-impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> Chipset<C::F> for PoseidonChipset<C, WIDTH>
+impl<C: PoseidonConfig<WIDTH> + 'static, const WIDTH: usize> Chipset<C::F>
+    for PoseidonChipset<C, WIDTH>
 where
     Sub1<C::R_P>: ArraySize,
 {

--- a/src/lurk/u64.rs
+++ b/src/lurk/u64.rs
@@ -225,7 +225,10 @@ impl<F: PrimeField32> Chipset<F> for U64 {
 mod test {
     use p3_baby_bear::BabyBear as F;
     use p3_field::AbstractField;
-    use sphinx_core::{stark::StarkMachine, utils::BabyBearPoseidon2};
+    use sphinx_core::{
+        stark::{StarkGenericConfig, StarkMachine},
+        utils::BabyBearPoseidon2,
+    };
 
     use crate::{
         air::debug::debug_chip_constraints_and_queries_with_sharding,
@@ -294,7 +297,7 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 
     #[test]
@@ -352,7 +355,7 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 
     #[test]
@@ -414,7 +417,7 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 
     #[test]
@@ -490,7 +493,7 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 
     #[test]
@@ -545,7 +548,7 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 
     #[test]
@@ -582,7 +585,7 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
 
         let mut queries = QueryRecord::new(&toplevel);
         let args = &[f(0), f(0), f(0), f(123), f(0), f(0), f(0), f(0)];
@@ -603,6 +606,6 @@ mod test {
 
         let (pk, _vk) = machine.setup(&LairMachineProgram);
         let shard = Shard::new(&queries);
-        machine.debug_constraints(&pk, shard.clone());
+        machine.debug_constraints(&pk, vec![shard], &mut machine.config().challenger());
     }
 }

--- a/src/poseidon/config.rs
+++ b/src/poseidon/config.rs
@@ -17,7 +17,9 @@ trait ConstantsProvided {}
 
 /// The Poseidon configuration trait storing the data needed for
 #[allow(non_camel_case_types, private_bounds)]
-pub trait PoseidonConfig<const WIDTH: usize>: Clone + Copy + Sync + ConstantsProvided {
+pub trait PoseidonConfig<const WIDTH: usize>:
+    Clone + Copy + Send + Sync + ConstantsProvided
+{
     type F: PrimeField;
     type R_P: ArraySize + Sub<B1>;
     type R_F: ArraySize;

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -6,7 +6,7 @@
 use p3_baby_bear::BabyBear;
 use p3_field::AbstractField;
 use sphinx_core::{
-    stark::{LocalProver, StarkGenericConfig, StarkMachine},
+    stark::{DefaultProver, MachineProver, StarkGenericConfig, StarkMachine},
     utils::{BabyBearPoseidon2, SphinxCoreOpts},
 };
 use std::time::Instant;
@@ -48,11 +48,7 @@ fn build_lurk_expr(arg: usize) -> String {
 fn setup<H: Chipset<BabyBear>>(
     arg: usize,
     toplevel: &Toplevel<BabyBear, H>,
-) -> (
-    List<BabyBear>,
-    FuncChip<'_, BabyBear, H>,
-    QueryRecord<BabyBear>,
-) {
+) -> (List<BabyBear>, FuncChip<BabyBear, H>, QueryRecord<BabyBear>) {
     let code = build_lurk_expr(arg);
     let zstore = &mut lurk_zstore();
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
@@ -91,7 +87,10 @@ fn fib_e2e() {
     let mut challenger_p = machine.config().challenger();
     let opts = SphinxCoreOpts::default();
     let shard = Shard::new(&record);
-    machine.prove::<LocalProver<_, _>>(&pk, shard, &mut challenger_p, opts);
+    let prover = DefaultProver::new(machine);
+    prover
+        .prove(&pk, vec![shard], &mut challenger_p, opts)
+        .unwrap();
 
     let elapsed_time = start_time.elapsed().as_secs_f32();
     println!("Total time for e2e-{arg} = {:.2} s", elapsed_time);


### PR DESCRIPTION
Companion PR for https://github.com/argumentcomputer/sphinx/pull/164

A handful of minor changes to be cleaned up later:

* `MachineAir` needs to be `'static + Send + Sync`, which meant removing many references in Lair structs
* The `prove` method is now a part of `DefaultProver`
* We apparently need to shard before proving

Consider this commit as "something that works" rather than "something good", a short list of things to clean up in follow-ups:

* Re-add sharing between Funcs, Toplevel, etc
* Factor out prove/verify code into our own Prover types
* Explicit sharding support in the prover