### PR TITLE
Issue 213

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -56,7 +56,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -56,7 +56,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -56,7 +56,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -60,7 +60,7 @@ fn setup<'a, H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -60,7 +60,7 @@ fn setup<'a, H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -60,7 +60,7 @@ fn setup<'a, H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -61,7 +61,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -61,7 +61,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -61,7 +61,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -192,7 +192,7 @@ ledger2
 
 ;; Now we can open the committed ledger transfer function on a transaction.
 
-!(call #0x85f1987c8573c6f96400270b87e2d215f8fe88b3c0b919acdae0cee9fcd5e2 '(1 0 2))
+!(call #0x266ad08765995fadb14f1efa2ade34af5669ccbc0fc2426ab4847c099c36e5 '(1 0 2))
 
 ;; And the record reflects that Church sent one unit to Satoshi.
 
@@ -202,7 +202,7 @@ ledger2
 
 ;; We can verify the proof..
 
-!(verify "447db46bdf1630b04d14ba94e793493e3aa5a5221e7cf9d9b2a18bad83ec59")
+!(verify "8bace909ec303b99d8355fc5308ae6967dbdf556a0d621c2cc853d436520a1")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -219,24 +219,24 @@ ledger2
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(chain #0x369702221fb6c0118dd8d2cd6299c8c1b095579076b378762d4168c37ff2c '(1 0 2))
+!(chain #0x85a7b9db0ace246928729f8559ec6732e39955797ca7b3684da5ca65d31bb1 '(1 0 2))
 
 !(prove)
 
-!(verify "8b4210c0343682fb1d60d6e6159958aee9c3fc1956235ea33b857be2619589")
+!(verify "328001e09d7c13b746e2613197ef61181cf2dfff408ce83c06a9cd9d298851")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(chain #0x4e45e27336abf9d4039593d0655bca393cbea54de651b7a32a265d5002c051 '(5 0 2))
+!(chain #0x29bad6bf2c02a583336bb375d83bf8c320015dbeb4752956fe5234075dca68 '(5 0 2))
 
 !(prove)
 
-!(verify "575cb510eddc56d66cbb857ab6ab84dbb574bd565183a0878adbf69fb82603")
+!(verify "5ee44f52fcb62c88535775c4ee3b634a91a5c52be467f8d58bd6bebf837ad3")
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(chain #0x1402764a9df0f83e60189990db00311bcfc1ae72e97d11e049a1b0309332ff '(20 1 0))
+!(chain #0x707aa8fdf6e887c1cc4f18ffe06aa2b3c175bb6d917fdb97b1eeb96f8e715d '(20 1 0))
 
 !(prove)
 
-!(verify "701727df3cd00c62c33c8324aa6462438574f9598c10e485e14466a80d0668")
+!(verify "5e5dda667246d9426db1b221730bb648533823b24fb7dbf7bd71363d14100f")

--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -207,13 +207,13 @@ ledger2
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
 
-!(def chain<-db (lambda (db salt)
+!(def chain<-db (lambda (db secret)
                    (letrec ((foo (lambda (state msg)
                                    (let ((new-state ((fn<-db state) msg)))
-                                     (cons new-state (hide salt (foo new-state)))))))
+                                     (cons new-state (hide secret (foo new-state)))))))
                      (foo db))))
 
-;; We'll call this on our ledger, and protect write-access with a salt value #0x999.
+;; We'll call this on our ledger, and protect write-access with a secret value #0x999.
 
 !(commit (chain<-db ledger #0x999))
 

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -9,7 +9,7 @@
 
 ;; We chain a next commitment by applying the committed function to a value of 9.
 
-!(chain #0x8ef25bc2228ca9799db65fd2b137a7b0ebccbfc04cf8530133e60087d403db 9)
+!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 9)
 
 ;; The new counter value is 9, and the function returns a new functional commitment.
 
@@ -21,11 +21,11 @@
 
 ;; We can verify the proof.
 
-!(verify "8930a611d0dcc7af859ea47e9c36cc418f8bbf039333e44325cb1d1e7fdbd4")
+!(verify "68bf8123715dcc0e230971dbff2edc365f5e0e1ec82518cda637b3ac49a4ab")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(chain #0x4fefa63f77fc4d76831ed199d2d58876d3f77ac629a6bc453da5410a0a423a 12)
+!(chain #0x7ef60daca90d37a29e5bb066615f925148f07ced803855f41907e7ace3d066 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 
@@ -35,11 +35,11 @@
 
 ;; And verify.
 
-!(verify "59bb86e6b8c460ef3742629c876fbeadea0ddcbb8bc6a5fdaec86dfc1c5dfb")
+!(verify "13b40e5aac59c950f2be0092c4c4f745be4c526711912933b8b3a466107cbb")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
-!(chain #0x1e45411221613c46ae6085b960ade79ab9751f9d918de85c058bfc43c74ecd 14)
+!(chain #0x7edc8f2fc3ddab594374d9e4344c7160f65b77b0e4f9da7292c63faa667fc7 14)
 
 ;; 21 + 14 = 35, as expected.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "7a36cc7454fbf3b0880b798eb21dcad540ab028a63ac45ebaac7c0a3198c80")
+!(verify "778deec686e6e2db8247630ca76c30665a44a5082f15d63a7737af83de1a46")
 
 ;; Repeat indefinitely.
 

--- a/demo/functional-commitment.lurk
+++ b/demo/functional-commitment.lurk
@@ -10,7 +10,7 @@
 
 ;; We open the functional commitment on input 5: Evaluate f(5).
 
-!(call #0x24243a2f507ea8fcb20e8ac5e663796e684ac81406803bc534bf85452ba6f2 5)
+!(call #0x584d533ca5f821e177459c56090fba62296b44f1cc289510332996224ac2ce 5)
 
 ;; We can prove the functional-commitment opening.
 
@@ -18,8 +18,8 @@
 
 ;; We can inspect the input/output expressions of the proof.
 
-!(inspect "5862775241522ce16db294dded18d925dec61de5a43d7f3dd04c533e779935")
+!(inspect "96aed5bd2fcfe3cd8ba52b6d0361b9af6fddc7a24729de7b9a9b1507802298")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(verify "5862775241522ce16db294dded18d925dec61de5a43d7f3dd04c533e779935")
+!(verify "96aed5bd2fcfe3cd8ba52b6d0361b9af6fddc7a24729de7b9a9b1507802298")

--- a/demo/protocol.lurk
+++ b/demo/protocol.lurk
@@ -10,13 +10,13 @@
   :description "hash opens to a pair (a, b) s.t. a+b=30 and a>10")
 
 ;; This is the prover's pair, whose hash is
-;; #0x896994f6258a01fbc7f21a81cb28a537259c3e97cc62da0a2773c63f9b4168
+;; #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc
 (commit '(13 . 17))
 
 ;; Let's prove it and write the proof to the file protocol-proof
 !(prove-protocol my-protocol
   "protocol-proof"
-  #0x896994f6258a01fbc7f21a81cb28a537259c3e97cc62da0a2773c63f9b4168
+  #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc
   '(13 . 17))
 
 ;; Now it can be verified

--- a/lib/macro.lurk
+++ b/lib/macro.lurk
@@ -2,10 +2,14 @@
 !(load "util.lurk")
 
 !(def not-immediate? (lambda (x)
-                       (if (type-eqq x x)
-                           t
-                           (if (type-eqq (0) x)
-                               t))))
+                       (if (eq nil x)
+                           nil
+                           (if (eq t x)
+                               nil
+                               (if (type-eqq x x)
+                                   t
+                                   (if (type-eqq (0) x)
+                                       t))))))
 
 !(def immediate? (lambda (x) (not (not-immediate? x))))
 

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -71,8 +71,8 @@
 !(assert-eq '(1 4 9 16) (map (lambda (x) (* x x)) '(1 2 3 4)))
 
 ;; permute
-!(assert-eq '(d b c a e) (permute '(a b c d e) 123))
-!(assert-eq '(e d a c b) (permute '(a b c d e) 987))
+!(assert-eq '(c b a d e) (permute '(a b c d e) 123))
+!(assert-eq '(b c d a e) (permute '(a b c d e) 987))
 
 ;; expt
 !(assert-eq 32 (expt 2 5))

--- a/src/lair/macros.rs
+++ b/src/lair/macros.rs
@@ -252,10 +252,6 @@ macro_rules! block {
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let $tgt:ident = $a:ident; $($tail:tt)+ }, $ops:expr) => {{
-        let $tgt = $a;
-        $crate::block!({ $($tail)* }, $ops)
-    }};
     ({ let $tgt:ident = $e:expr; $($tail:tt)+ }, $ops:expr) => {{
         $ops.push($crate::lair::expr::OpE::Const($crate::var!($tgt), $e.to_field()));
         let $tgt = $crate::var!($tgt);

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -13,7 +13,7 @@ use crate::loam::{LEWrap, Ptr, Wide, WidePtr, LE};
 
 use crate::lurk::chipset::{lurk_hasher, LurkHasher};
 use crate::lurk::tag::Tag;
-use crate::lurk::zstore::{DIGEST_SIZE, HASH3_SIZE, HASH4_SIZE, HASH6_SIZE};
+use crate::lurk::zstore::{DIGEST_SIZE, HASH3_SIZE, HASH4_SIZE};
 
 use crate::lurk::{
     chipset::LurkChip,
@@ -85,26 +85,26 @@ impl Allocator {
         }
     }
 
-    /// TODO: reorg for duplicate code
-    pub fn import_hashes6(&mut self, hashes6: &FxHashMap<[LE; HASH6_SIZE], [LE; DIGEST_SIZE]>) {
-        for (preimage, digest) in hashes6 {
-            let preimage_vec = preimage
-                .chunks(8)
-                .map(|chunk| Wide::from_slice(chunk))
-                .collect::<Vec<_>>();
-            let digest_wide = Wide(digest.clone());
+    // /// TODO: reorg for duplicate code
+    // pub fn import_hashes6(&mut self, hashes6: &FxHashMap<[LE; HASH6_SIZE], [LE; DIGEST_SIZE]>) {
+    //     for (preimage, digest) in hashes6 {
+    //         let preimage_vec = preimage
+    //             .chunks(8)
+    //             .map(|chunk| Wide::from_slice(chunk))
+    //             .collect::<Vec<_>>();
+    //         let digest_wide = Wide(digest.clone());
 
-            self.digest_cache
-                .insert(preimage_vec.clone(), digest_wide.clone());
+    //         self.digest_cache
+    //             .insert(preimage_vec.clone(), digest_wide.clone());
 
-            self.preimage_cache.insert(digest_wide, preimage_vec);
-        }
-    }
+    //         self.preimage_cache.insert(digest_wide, preimage_vec);
+    //     }
+    // }
 
     pub fn import_zstore(&mut self, zstore: &ZStore<LE, LurkChip>) {
-        self.import_hashes3(&zstore.hashes3);
-        self.import_hashes4(&zstore.hashes4);
-        self.import_hashes6(&zstore.hashes6);
+        self.import_hashes3(&zstore.hashes24);
+        self.import_hashes4(&zstore.hashes32);
+        // self.import_hashes6(&zstore.hashes48);
     }
 
     pub fn alloc_addr(&mut self, tag: LE, initial_addr: LE) -> LE {

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -13,7 +13,7 @@ use crate::loam::{LEWrap, Ptr, Wide, WidePtr, LE};
 
 use crate::lurk::chipset::{lurk_hasher, LurkHasher};
 use crate::lurk::tag::Tag;
-use crate::lurk::zstore::{COMPACT110_SIZE, DIGEST_SIZE, HASH3_SIZE, HASH4_SIZE};
+use crate::lurk::zstore::{DIGEST_SIZE, HASH3_SIZE, HASH4_SIZE, HASH5_SIZE};
 
 use crate::lurk::{
     chipset::LurkChip,
@@ -86,10 +86,7 @@ impl Allocator {
     }
 
     // /// TODO: reorg for duplicate code
-    pub fn import_hashes5(
-        &mut self,
-        hashes5: &FxHashMap<[LE; COMPACT110_SIZE], [LE; DIGEST_SIZE]>,
-    ) {
+    pub fn import_hashes5(&mut self, hashes5: &FxHashMap<[LE; HASH5_SIZE], [LE; DIGEST_SIZE]>) {
         for (preimage, digest) in hashes5 {
             let preimage_vec = preimage
                 .chunks(8)
@@ -105,9 +102,9 @@ impl Allocator {
     }
 
     pub fn import_zstore(&mut self, zstore: &ZStore<LE, LurkChip>) {
-        self.import_hashes3(&zstore.hashes24);
-        self.import_hashes4(&zstore.hashes32);
-        self.import_hashes5(&zstore.hashes40);
+        self.import_hashes3(&zstore.hashes3);
+        self.import_hashes4(&zstore.hashes4);
+        self.import_hashes5(&zstore.hashes5);
     }
 
     pub fn alloc_addr(&mut self, tag: LE, initial_addr: LE) -> LE {

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -174,8 +174,8 @@ impl Allocator {
 
         self.preimage_cache
             .get(digest)
-            .map(|digest| {
-                preimage.copy_from_slice(&digest[..4]);
+            .map(|preimg| {
+                preimage.copy_from_slice(&preimg[..4]);
                 preimage
             })
             .unwrap()
@@ -186,8 +186,8 @@ impl Allocator {
 
         self.preimage_cache
             .get(digest)
-            .map(|digest| {
-                preimage.copy_from_slice(&digest[..5]);
+            .map(|preimg| {
+                preimage.copy_from_slice(&preimg[..5]);
                 preimage
             })
             .unwrap()

--- a/src/loam/distilled_evaluation.rs
+++ b/src/loam/distilled_evaluation.rs
@@ -9,7 +9,7 @@ use crate::loam::lurk_sym_index;
 use crate::loam::memory::{initial_tag_relation, Memory};
 use crate::loam::{LEWrap, LoamProgram, Num, Ptr, PtrEq, Wide, WidePtr, LE};
 use crate::lurk::chipset::LurkChip;
-use crate::lurk::state::LURK_PACKAGE_SYMBOLS_NAMES;
+use crate::lurk::state::BUILTIN_SYMBOLS;
 use crate::lurk::tag::Tag;
 use crate::lurk::zstore::{builtin_vec, lurk_zstore, ZPtr};
 

--- a/src/loam/distilled_evaluation.rs
+++ b/src/loam/distilled_evaluation.rs
@@ -57,11 +57,11 @@ ascent! {
     relation hash4_rel(Wide, Wide, Wide, Wide, Wide); // (a, b, c, d, tag, digest)
 
     // Final
-    relation hash6(Wide, Wide, Wide, Wide, Wide, Wide); // (a, b, c, d, e, f)
+    relation hash5(Wide, Wide, Wide, Wide, Wide); // (a, b, c, d, e)
     // Signal
-    relation unhash6(Wide); // (tag, digest)
+    relation unhash5(Wide); // (tag, digest)
     // Final
-    relation hash6_rel(Wide, Wide, Wide, Wide, Wide, Wide, Wide); // (a, b, c, d, e, f, tag, digest)
+    relation hash5_rel(Wide, Wide, Wide, Wide, Wide, Wide); // (a, b, c, d, e, digest)
 
     // Signal
     relation egress(Ptr); // (ptr)
@@ -143,33 +143,31 @@ ascent! {
         fun_mem(args, body, closed_env, addr),
         let fun = Ptr(Tag::Fun.elt(), *addr);
 
-    // Populate ptr_value if a fun_rel has been hashed in hash6_rel.
+    // Populate ptr_value if a fun_rel has been hashed in hash5_rel.
     ptr_value(fun, digest) <--
         fun_rel(args, body, closed_env, fun),
         ptr_value(args, args_value), ptr_value(body, body_value), ptr_value(closed_env, closed_env_value),
-        hash6_rel(
+        hash5_rel(
             args.wide_tag(),
             args_value,
             body.wide_tag(),
             body_value,
-            closed_env.wide_tag(),
             closed_env_value,
             digest,
         );
     // Other way around
     fun_rel(args, body, closed_env, fun) <--
         ptr_value(fun, digest), if fun.tag() == Tag::Fun,
-        hash6_rel(
+        hash5_rel(
             args_tag,
             args_value,
             body_tag,
             body_value,
-            closed_env_tag,
             closed_env_value,
             digest,
         ),
         ptr_value(args, args_value), ptr_value(body, body_value), ptr_value(closed_env, closed_env_value),
-        if args.wide_tag() == *args_tag && body.wide_tag() == *body_tag && closed_env.wide_tag() == *closed_env_tag;
+        if args.wide_tag() == *args_tag && body.wide_tag() == *body_tag && Tag::Cons == closed_env.tag();
 
     ////////////////////////////////////////////////////////////////////////////////
     // Thunk
@@ -218,7 +216,6 @@ ascent! {
     relation sym_digest_mem(Wide, LE); // (digest, addr)
 
     ptr_value(ptr, value) <-- sym_digest_mem(value, addr), let ptr = Ptr(Tag::Sym.elt(), *addr);
-    // todo: sym_value
 
     ////////////////////////////////////////////////////////////////////////////////
     // Builtin
@@ -227,16 +224,6 @@ ascent! {
     relation builtin_digest_mem(Wide, LE); // (digest, addr)
 
     ptr_value(ptr, value) <-- builtin_digest_mem(value, addr), let ptr = Ptr(Tag::Builtin.elt(), *addr);
-    // todo: builtin_value
-
-    ////////////////////////////////////////////////////////////////////////////////
-    // Nil
-
-    // Final
-    // Can this be combined with sym_digest_mem? Can it be eliminated? (probably eventually).
-    relation nil_digest_mem(Wide, LE); // (digest, addr)
-
-    ptr_value(ptr, value) <-- nil_digest_mem(value, addr), let ptr = Ptr(Tag::Nil.elt(), *addr);
 
     ////////////////////////////////////////////////////////////////////////////////
     // Num
@@ -271,17 +258,16 @@ ascent! {
         tag(y_tag, wide_y_tag);
 
     // mark ingress funs for unhashing
-    unhash6(digest) <-- ingress(ptr), if ptr.is_fun(), ptr_value(ptr, digest);
+    unhash5(digest) <-- ingress(ptr), if ptr.is_fun(), ptr_value(ptr, digest);
 
-    hash6_rel(a, b, c, d, e, f, digest) <--
-        unhash6(digest), let [a, b, c, d, e, f] = _self.allocator.unhash6(digest);
+    hash5_rel(a, b, c, d, e, digest) <--
+        unhash5(digest), let [a, b, c, d, e] = _self.allocator.unhash5(digest);
 
-    alloc(x_tag, x_value), alloc(y_tag, y_value), alloc(z_tag, z_value) <--
-        unhash6(digest),
-        hash6_rel(wide_x_tag, x_value, wide_y_tag, y_value, wide_z_tag, z_value, digest),
+    alloc(x_tag, x_value), alloc(y_tag, y_value), alloc(Tag::Cons.elt(), z_value) <--
+        unhash5(digest),
+        hash5_rel(wide_x_tag, x_value, wide_y_tag, y_value, z_value, digest),
         tag(x_tag, wide_x_tag),
-        tag(y_tag, wide_y_tag),
-        tag(z_tag, wide_z_tag);
+        tag(y_tag, wide_y_tag);
 
     ////////////////////////////////////////////////////////////////////////////////
     // Egress path
@@ -320,15 +306,15 @@ ascent! {
         hash4(a, b, c, d), let digest = _self.allocator.hash4(*a, *b, *c, *d);
 
     // Fun
-    hash6(args.wide_tag(), args_value, body.wide_tag(), body_value, closed_env.wide_tag(), closed_env_value) <--
+    hash5(args.wide_tag(), args_value, body.wide_tag(), body_value, closed_env_value) <--
         egress(fun),
         fun_rel(args, body, closed_env, fun),
         ptr_value(args, args_value),
         ptr_value(body, body_value),
         ptr_value(closed_env, closed_env_value);
 
-    hash6_rel(a, b, c, d, e, f, digest) <--
-        hash6(a, b, c, d, e, f), let digest = _self.allocator.hash6(*a, *b, *c, *d, *e, *f);
+    hash5_rel(a, b, c, d, e, digest) <--
+        hash5(a, b, c, d, e), let digest = _self.allocator.hash5(*a, *b, *c, *d, *e);
 
     ////////////////////////////////////////////////////////////////////////////////
     // eval
@@ -1022,7 +1008,6 @@ impl DistilledEvaluationProgram {
 
         self.sym_digest_mem = memory.sym_digest_mem;
         self.builtin_digest_mem = memory.builtin_digest_mem;
-        self.nil_digest_mem = memory.nil_digest_mem;
     }
 }
 

--- a/src/loam/distilled_evaluation.rs
+++ b/src/loam/distilled_evaluation.rs
@@ -11,7 +11,7 @@ use crate::loam::{LEWrap, LoamProgram, Num, Ptr, PtrEq, Wide, WidePtr, LE};
 use crate::lurk::chipset::LurkChip;
 use crate::lurk::state::BUILTIN_SYMBOLS;
 use crate::lurk::tag::Tag;
-use crate::lurk::zstore::{builtin_vec, lurk_zstore, ZPtr};
+use crate::lurk::zstore::{builtin_set, lurk_zstore, ZPtr};
 
 use p3_field::{AbstractField, Field, PrimeField32};
 

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -14,7 +14,7 @@ use crate::loam::memory::{
 };
 use crate::loam::{LEWrap, LoamProgram, Num, Ptr, PtrEq, Wide, WidePtr, LE};
 use crate::lurk::chipset::LurkChip;
-use crate::lurk::state::LURK_PACKAGE_SYMBOLS_NAMES;
+use crate::lurk::state::BUILTIN_SYMBOLS;
 use crate::lurk::tag::Tag;
 use crate::lurk::zstore::{builtin_vec, lurk_zstore, ZPtr, ZStore};
 
@@ -175,7 +175,7 @@ impl Ptr {
         if idx >= 18 {
             idx += 1;
         }
-        LURK_PACKAGE_SYMBOLS_NAMES[idx]
+        BUILTIN_SYMBOLS[idx]
     }
 }
 

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -16,7 +16,7 @@ use crate::loam::{LEWrap, LoamProgram, Num, Ptr, PtrEq, Wide, WidePtr, LE};
 use crate::lurk::chipset::LurkChip;
 use crate::lurk::state::BUILTIN_SYMBOLS;
 use crate::lurk::tag::Tag;
-use crate::lurk::zstore::{builtin_vec, lurk_zstore, ZPtr, ZStore};
+use crate::lurk::zstore::{builtin_set, lurk_zstore, ZPtr, ZStore};
 
 use p3_field::{AbstractField, Field, PrimeField32};
 

--- a/src/loam/memory.rs
+++ b/src/loam/memory.rs
@@ -83,6 +83,14 @@ impl PPtr {
         PPtr(Ptr(tag.elt(), LE::from_canonical_u32(addr)))
     }
 
+    fn nil() -> Self {
+        PPtr(Ptr::nil())
+    }
+
+    fn t() -> Self {
+        PPtr(Ptr::t())
+    }
+
     fn num(addr: u32) -> Self {
         PPtr::new(Tag::Num, addr)
     }
@@ -347,7 +355,6 @@ impl Store {
                 ptr
             }
             Tag::Sym => PPtr(vptr.0),
-            Tag::Nil => PPtr(vptr.0),
             Tag::Num => PPtr(vptr.0),
             Tag::Err => PPtr(vptr.0),
             Tag::Builtin => PPtr(vptr.0),
@@ -435,7 +442,6 @@ impl Store {
             let tag = ptr.tag();
             match tag {
                 Tag::Sym => memory.sym_digest_mem.push((*digest, ptr.addr())),
-                Tag::Nil => memory.nil_digest_mem.push((*digest, ptr.addr())),
                 Tag::Builtin => memory.builtin_digest_mem.push((*digest, ptr.addr())),
                 Tag::Num => (),
                 _ => panic!("unimplemented: {:?}", &ptr),
@@ -462,14 +468,14 @@ impl Store {
     }
 
     pub fn fetch_list<'a>(&'a self, mut ptr: &'a PPtr) -> (Vec<&PPtr>, Option<&'a PPtr>) {
-        assert!(matches!(ptr.tag(), Tag::Cons | Tag::Nil));
+        assert!(ptr.tag() == Tag::Cons || ptr == &PPtr::nil());
         let mut elts = vec![];
         while ptr.tag() == Tag::Cons {
             let (car, cdr) = self.fetch_tuple2(ptr);
             elts.push(car);
             ptr = cdr;
         }
-        if ptr.tag() == Tag::Nil {
+        if ptr == &PPtr::nil() {
             (elts, None)
         } else {
             (elts, Some(ptr))
@@ -484,7 +490,7 @@ impl Store {
     pub fn fmt(&self, zstore: &ZStore<LE, LurkChip>, ptr: &PPtr) -> String {
         match ptr.tag() {
             Tag::Num => format!("{}n", ptr.addr()),
-            Tag::Builtin | Tag::BigNum | Tag::Sym | Tag::Key | Tag::Nil => self
+            Tag::Builtin | Tag::BigNum | Tag::Sym | Tag::Key => self
                 .pptr_digest
                 .get(ptr)
                 .map(|digest| {
@@ -506,7 +512,7 @@ impl Store {
             }
             Tag::Fun => {
                 let (args, body, _) = self.fetch_tuple3(ptr);
-                if args.tag() == Tag::Nil {
+                if args == &PPtr::nil() {
                     format!("<Fun () {}>", self.fmt(zstore, body))
                 } else {
                     format!(

--- a/src/loam/memory.rs
+++ b/src/loam/memory.rs
@@ -10,7 +10,7 @@ use crate::{
     lurk::{
         chipset::LurkChip,
         eval::EvalErr,
-        state::{StateRcCell, LURK_PACKAGE_SYMBOLS_NAMES},
+        state::{StateRcCell, BUILTIN_SYMBOLS},
         tag::Tag,
         zstore::{self, builtin_vec, lurk_zstore, ZPtr, ZStore},
     },
@@ -540,12 +540,12 @@ pub fn initial_builtin_relation() -> Vec<(Wide, Dual<LEWrap>)> {
 }
 
 pub fn initial_builtin_addr() -> LE {
-    LE::from_canonical_u64(LURK_PACKAGE_SYMBOLS_NAMES.len() as u64)
+    LE::from_canonical_u64(BUILTIN_SYMBOLS.len() as u64)
 }
 
 pub fn initial_nil_relation() -> Vec<(Wide, Dual<LEWrap>)> {
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag: _, digest } = zstore.intern_nil();
+    let ZPtr { tag: _, digest } = *zstore.nil();
     vec![(Wide(digest), Dual(LEWrap(LE::from_canonical_u64(0u64))))]
 }
 

--- a/src/loam/memory.rs
+++ b/src/loam/memory.rs
@@ -543,6 +543,27 @@ pub fn initial_builtin_addr() -> LE {
     LE::from_canonical_u64(BUILTIN_SYMBOLS.len() as u64)
 }
 
+pub fn initial_symbol_relation() -> Vec<(Wide, Dual<LEWrap>)> {
+    let zstore = &mut lurk_zstore();
+
+    let ZPtr {
+        tag: _,
+        digest: nil_digest,
+    } = *zstore.nil();
+    let ZPtr {
+        tag: _,
+        digest: t_digest,
+    } = *zstore.t();
+    vec![
+        (Wide(nil_digest), Dual(LEWrap(LE::zero()))),
+        (Wide(t_digest), Dual(LEWrap(LE::one()))),
+    ]
+}
+
+pub fn initial_symbol_addr() -> LE {
+    LE::from_canonical_u64(2)
+}
+
 pub fn initial_nil_relation() -> Vec<(Wide, Dual<LEWrap>)> {
     let zstore = &mut lurk_zstore();
     let ZPtr { tag: _, digest } = *zstore.nil();

--- a/src/loam/memory.rs
+++ b/src/loam/memory.rs
@@ -12,7 +12,7 @@ use crate::{
         eval::EvalErr,
         state::{StateRcCell, BUILTIN_SYMBOLS},
         tag::Tag,
-        zstore::{self, builtin_vec, lurk_zstore, ZPtr, ZStore},
+        zstore::{self, builtin_set, lurk_zstore, ZPtr, ZStore},
     },
 };
 
@@ -528,7 +528,7 @@ impl Store {
 
 pub fn initial_builtin_relation() -> Vec<(Wide, Dual<LEWrap>)> {
     let zstore = &mut lurk_zstore();
-    builtin_vec()
+    builtin_set()
         .iter()
         .enumerate()
         .map(|(i, name)| {

--- a/src/loam/mod.rs
+++ b/src/loam/mod.rs
@@ -11,7 +11,7 @@ use p3_field::{AbstractField, PrimeField32};
 use rustc_hash::FxHashMap;
 
 use crate::lurk::chipset::LurkChip;
-use crate::lurk::state::LURK_PACKAGE_SYMBOLS_NAMES;
+use crate::lurk::state::BUILTIN_SYMBOLS;
 use crate::lurk::tag::Tag;
 use crate::lurk::zstore::{self, lurk_zstore, ZPtr, ZStore};
 
@@ -231,7 +231,7 @@ impl WidePtr {
     fn nil() -> Self {
         // FIXME: cache, don't do expensive read repeatedly.
         let zstore = &mut lurk_zstore();
-        let ZPtr { tag, digest } = zstore.intern_nil();
+        let ZPtr { tag, digest } = *zstore.nil();
         Self(Wide::widen(tag.elt()), Wide(digest))
     }
 
@@ -338,8 +338,5 @@ trait LoamProgram {
 
 // TODO: This can use a hashtable lookup, or could even be known at compile-time (but how to make that non-brittle since iter() is not const?).
 pub(crate) fn lurk_sym_index(name: &str) -> Option<usize> {
-    LURK_PACKAGE_SYMBOLS_NAMES
-        .iter()
-        .filter(|name| **name != "nil")
-        .position(|s| *s == name)
+    BUILTIN_SYMBOLS.iter().position(|s| *s == name)
 }

--- a/src/loam/mod.rs
+++ b/src/loam/mod.rs
@@ -58,19 +58,18 @@ pub struct Ptr(pub LE, pub LE);
 
 impl Ptr {
     fn nil() -> Self {
-        // nil is zeroth element in the nil-typed table.
-        Self(Tag::Nil.elt(), LE::from_canonical_u32(0))
+        Self(Tag::Sym.elt(), LE::zero())
+    }
+
+    /// make this const
+    fn t() -> Self {
+        Self(Tag::Sym.elt(), LE::one())
     }
 
     /// make this const
     fn builtin(op: &str) -> Self {
         let addr = lurk_sym_index(op).unwrap();
         Self(Tag::Builtin.elt(), LE::from_canonical_u32(addr as u32))
-    }
-
-    /// make this const
-    fn t() -> Self {
-        Self::builtin("t")
     }
 
     /// make this const
@@ -113,11 +112,12 @@ impl Ptr {
         self.0 == Tag::Cons.elt()
     }
     fn is_nil(&self) -> bool {
-        // TODO: should we also check value?
-        self.0 == Tag::Nil.elt()
+        *self == Ptr::nil()
     }
     fn is_sym(&self) -> bool {
-        self.0 == Tag::Sym.elt()
+        // TODO: this is hardcoded to not consider nil/t as syms that should be
+        // looked up in head position -- not sure how this is going to be in-circuit
+        self.0 == Tag::Sym.elt() && self.1 != LE::zero() && self.1 != LE::one()
     }
 
     fn is_builtin(&self) -> bool {
@@ -294,12 +294,12 @@ trait LoamProgram {
         self.allocator_mut().hash4(a, b, c, d)
     }
 
-    fn unhash6(&mut self, digest: &Wide) -> [Wide; 6] {
-        self.allocator_mut().unhash6(digest)
+    fn unhash5(&mut self, digest: &Wide) -> [Wide; 5] {
+        self.allocator_mut().unhash5(digest)
     }
 
-    fn hash6(&mut self, a: Wide, b: Wide, c: Wide, d: Wide, e: Wide, f: Wide) -> Wide {
-        self.allocator_mut().hash6(a, b, c, d, e, f)
+    fn hash5(&mut self, a: Wide, b: Wide, c: Wide, d: Wide, e: Wide) -> Wide {
+        self.allocator_mut().hash5(a, b, c, d, e)
     }
 
     fn export_memory(&self) -> VirtualMemory {

--- a/src/lurk/chipset.rs
+++ b/src/lurk/chipset.rs
@@ -4,7 +4,7 @@ use p3_baby_bear::BabyBear;
 use crate::{
     air::builder::{LookupBuilder, Record, RequireRecord},
     lair::{chipset::Chipset, execute::QueryRecord},
-    poseidon::config::{BabyBearConfig24, BabyBearConfig32, BabyBearConfig48},
+    poseidon::config::{BabyBearConfig24, BabyBearConfig32, BabyBearConfig40},
 };
 
 use crate::lair::{map::Map, Name};
@@ -16,7 +16,7 @@ use super::{big_num::BigNum, u64::U64, zstore::Hasher};
 pub enum LurkChip {
     Hasher24_8(PoseidonChipset<BabyBearConfig24, 24>),
     Hasher32_8(PoseidonChipset<BabyBearConfig32, 32>),
-    Hasher48_8(PoseidonChipset<BabyBearConfig48, 48>),
+    Hasher40_8(PoseidonChipset<BabyBearConfig40, 40>),
     U64(U64),
     BigNum(BigNum),
 }
@@ -24,7 +24,7 @@ pub enum LurkChip {
 pub fn lurk_chip_map() -> Map<Name, LurkChip> {
     let hash_24_8 = LurkChip::Hasher24_8(PoseidonChipset::default());
     let hash_32_8 = LurkChip::Hasher32_8(PoseidonChipset::default());
-    let hash_48_8 = LurkChip::Hasher48_8(PoseidonChipset::default());
+    let hash_40_8 = LurkChip::Hasher40_8(PoseidonChipset::default());
     let u64_add = LurkChip::U64(U64::Add);
     let u64_sub = LurkChip::U64(U64::Sub);
     let u64_mul = LurkChip::U64(U64::Mul);
@@ -35,7 +35,7 @@ pub fn lurk_chip_map() -> Map<Name, LurkChip> {
     let vec = vec![
         (Name("hash_24_8"), hash_24_8),
         (Name("hash_32_8"), hash_32_8),
-        (Name("hash_48_8"), hash_48_8),
+        (Name("hash_40_8"), hash_40_8),
         (Name("u64_add"), u64_add),
         (Name("u64_sub"), u64_sub),
         (Name("u64_mul"), u64_mul),
@@ -53,7 +53,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(op) => op.input_size(),
             LurkChip::Hasher32_8(op) => op.input_size(),
-            LurkChip::Hasher48_8(op) => op.input_size(),
+            LurkChip::Hasher40_8(op) => op.input_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::input_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::input_size(op),
         }
@@ -64,7 +64,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(op) => op.output_size(),
             LurkChip::Hasher32_8(op) => op.output_size(),
-            LurkChip::Hasher48_8(op) => op.output_size(),
+            LurkChip::Hasher40_8(op) => op.output_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::output_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::output_size(op),
         }
@@ -74,7 +74,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(op) => op.witness_size(),
             LurkChip::Hasher32_8(op) => op.witness_size(),
-            LurkChip::Hasher48_8(op) => op.witness_size(),
+            LurkChip::Hasher40_8(op) => op.witness_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::witness_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::witness_size(op),
         }
@@ -84,7 +84,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(op) => op.require_size(),
             LurkChip::Hasher32_8(op) => op.require_size(),
-            LurkChip::Hasher48_8(op) => op.require_size(),
+            LurkChip::Hasher40_8(op) => op.require_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::require_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::require_size(op),
         }
@@ -94,7 +94,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(hasher) => hasher.execute_simple(input),
             LurkChip::Hasher32_8(hasher) => hasher.execute_simple(input),
-            LurkChip::Hasher48_8(hasher) => hasher.execute_simple(input),
+            LurkChip::Hasher40_8(hasher) => hasher.execute_simple(input),
             LurkChip::U64(..) | LurkChip::BigNum(..) => panic!("use `execute`"),
         }
     }
@@ -109,7 +109,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(hasher) => hasher.execute(input, nonce, queries, requires),
             LurkChip::Hasher32_8(hasher) => hasher.execute(input, nonce, queries, requires),
-            LurkChip::Hasher48_8(hasher) => hasher.execute(input, nonce, queries, requires),
+            LurkChip::Hasher40_8(hasher) => hasher.execute(input, nonce, queries, requires),
             LurkChip::U64(op) => op.execute(input, nonce, queries, requires),
             LurkChip::BigNum(op) => op.execute(input, nonce, queries, requires),
         }
@@ -119,7 +119,7 @@ impl Chipset<BabyBear> for LurkChip {
         match self {
             LurkChip::Hasher24_8(hasher) => hasher.populate_witness(input, witness),
             LurkChip::Hasher32_8(hasher) => hasher.populate_witness(input, witness),
-            LurkChip::Hasher48_8(hasher) => hasher.populate_witness(input, witness),
+            LurkChip::Hasher40_8(hasher) => hasher.populate_witness(input, witness),
             LurkChip::U64(op) => op.populate_witness(input, witness),
             LurkChip::BigNum(op) => op.populate_witness(input, witness),
         }
@@ -141,7 +141,7 @@ impl Chipset<BabyBear> for LurkChip {
             LurkChip::Hasher32_8(hasher) => {
                 hasher.eval(builder, is_real, preimg, witness, nonce, requires)
             }
-            LurkChip::Hasher48_8(hasher) => {
+            LurkChip::Hasher40_8(hasher) => {
                 hasher.eval(builder, is_real, preimg, witness, nonce, requires)
             }
             LurkChip::U64(op) => op.eval(builder, is_real, preimg, witness, nonce, requires),
@@ -157,6 +157,6 @@ pub fn lurk_hasher() -> LurkHasher {
     Hasher::new(
         LurkChip::Hasher24_8(PoseidonChipset::default()),
         LurkChip::Hasher32_8(PoseidonChipset::default()),
-        LurkChip::Hasher48_8(PoseidonChipset::default()),
+        LurkChip::Hasher40_8(PoseidonChipset::default()),
     )
 }

--- a/src/lurk/chipset.rs
+++ b/src/lurk/chipset.rs
@@ -14,17 +14,17 @@ use super::{big_num::BigNum, u64::U64, zstore::Hasher};
 
 #[derive(Clone)]
 pub enum LurkChip {
-    Hasher24_8(PoseidonChipset<BabyBearConfig24, 24>),
-    Hasher32_8(PoseidonChipset<BabyBearConfig32, 32>),
-    Hasher40_8(PoseidonChipset<BabyBearConfig40, 40>),
+    Hasher3(PoseidonChipset<BabyBearConfig24, 24>),
+    Hasher4(PoseidonChipset<BabyBearConfig32, 32>),
+    Hasher5(PoseidonChipset<BabyBearConfig40, 40>),
     U64(U64),
     BigNum(BigNum),
 }
 
 pub fn lurk_chip_map() -> Map<Name, LurkChip> {
-    let hash_24_8 = LurkChip::Hasher24_8(PoseidonChipset::default());
-    let hash_32_8 = LurkChip::Hasher32_8(PoseidonChipset::default());
-    let hash_40_8 = LurkChip::Hasher40_8(PoseidonChipset::default());
+    let hasher3 = LurkChip::Hasher3(PoseidonChipset::default());
+    let hasher4 = LurkChip::Hasher4(PoseidonChipset::default());
+    let hasher5 = LurkChip::Hasher5(PoseidonChipset::default());
     let u64_add = LurkChip::U64(U64::Add);
     let u64_sub = LurkChip::U64(U64::Sub);
     let u64_mul = LurkChip::U64(U64::Mul);
@@ -33,9 +33,9 @@ pub fn lurk_chip_map() -> Map<Name, LurkChip> {
     let u64_iszero = LurkChip::U64(U64::IsZero);
     let big_num_lessthan = LurkChip::BigNum(BigNum::LessThan);
     let vec = vec![
-        (Name("hash_24_8"), hash_24_8),
-        (Name("hash_32_8"), hash_32_8),
-        (Name("hash_40_8"), hash_40_8),
+        (Name("hasher3"), hasher3),
+        (Name("hasher4"), hasher4),
+        (Name("hasher5"), hasher5),
         (Name("u64_add"), u64_add),
         (Name("u64_sub"), u64_sub),
         (Name("u64_mul"), u64_mul),
@@ -51,9 +51,9 @@ impl Chipset<BabyBear> for LurkChip {
     #[inline]
     fn input_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(op) => op.input_size(),
-            LurkChip::Hasher32_8(op) => op.input_size(),
-            LurkChip::Hasher40_8(op) => op.input_size(),
+            LurkChip::Hasher3(op) => op.input_size(),
+            LurkChip::Hasher4(op) => op.input_size(),
+            LurkChip::Hasher5(op) => op.input_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::input_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::input_size(op),
         }
@@ -62,9 +62,9 @@ impl Chipset<BabyBear> for LurkChip {
     #[inline]
     fn output_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(op) => op.output_size(),
-            LurkChip::Hasher32_8(op) => op.output_size(),
-            LurkChip::Hasher40_8(op) => op.output_size(),
+            LurkChip::Hasher3(op) => op.output_size(),
+            LurkChip::Hasher4(op) => op.output_size(),
+            LurkChip::Hasher5(op) => op.output_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::output_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::output_size(op),
         }
@@ -72,9 +72,9 @@ impl Chipset<BabyBear> for LurkChip {
 
     fn witness_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(op) => op.witness_size(),
-            LurkChip::Hasher32_8(op) => op.witness_size(),
-            LurkChip::Hasher40_8(op) => op.witness_size(),
+            LurkChip::Hasher3(op) => op.witness_size(),
+            LurkChip::Hasher4(op) => op.witness_size(),
+            LurkChip::Hasher5(op) => op.witness_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::witness_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::witness_size(op),
         }
@@ -82,9 +82,9 @@ impl Chipset<BabyBear> for LurkChip {
 
     fn require_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(op) => op.require_size(),
-            LurkChip::Hasher32_8(op) => op.require_size(),
-            LurkChip::Hasher40_8(op) => op.require_size(),
+            LurkChip::Hasher3(op) => op.require_size(),
+            LurkChip::Hasher4(op) => op.require_size(),
+            LurkChip::Hasher5(op) => op.require_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::require_size(op),
             LurkChip::BigNum(op) => <BigNum as Chipset<BabyBear>>::require_size(op),
         }
@@ -92,9 +92,9 @@ impl Chipset<BabyBear> for LurkChip {
 
     fn execute_simple(&self, input: &[BabyBear]) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher24_8(hasher) => hasher.execute_simple(input),
-            LurkChip::Hasher32_8(hasher) => hasher.execute_simple(input),
-            LurkChip::Hasher40_8(hasher) => hasher.execute_simple(input),
+            LurkChip::Hasher3(hasher) => hasher.execute_simple(input),
+            LurkChip::Hasher4(hasher) => hasher.execute_simple(input),
+            LurkChip::Hasher5(hasher) => hasher.execute_simple(input),
             LurkChip::U64(..) | LurkChip::BigNum(..) => panic!("use `execute`"),
         }
     }
@@ -107,9 +107,9 @@ impl Chipset<BabyBear> for LurkChip {
         requires: &mut Vec<Record>,
     ) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher24_8(hasher) => hasher.execute(input, nonce, queries, requires),
-            LurkChip::Hasher32_8(hasher) => hasher.execute(input, nonce, queries, requires),
-            LurkChip::Hasher40_8(hasher) => hasher.execute(input, nonce, queries, requires),
+            LurkChip::Hasher3(hasher) => hasher.execute(input, nonce, queries, requires),
+            LurkChip::Hasher4(hasher) => hasher.execute(input, nonce, queries, requires),
+            LurkChip::Hasher5(hasher) => hasher.execute(input, nonce, queries, requires),
             LurkChip::U64(op) => op.execute(input, nonce, queries, requires),
             LurkChip::BigNum(op) => op.execute(input, nonce, queries, requires),
         }
@@ -117,9 +117,9 @@ impl Chipset<BabyBear> for LurkChip {
 
     fn populate_witness(&self, input: &[BabyBear], witness: &mut [BabyBear]) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher24_8(hasher) => hasher.populate_witness(input, witness),
-            LurkChip::Hasher32_8(hasher) => hasher.populate_witness(input, witness),
-            LurkChip::Hasher40_8(hasher) => hasher.populate_witness(input, witness),
+            LurkChip::Hasher3(hasher) => hasher.populate_witness(input, witness),
+            LurkChip::Hasher4(hasher) => hasher.populate_witness(input, witness),
+            LurkChip::Hasher5(hasher) => hasher.populate_witness(input, witness),
             LurkChip::U64(op) => op.populate_witness(input, witness),
             LurkChip::BigNum(op) => op.populate_witness(input, witness),
         }
@@ -135,13 +135,13 @@ impl Chipset<BabyBear> for LurkChip {
         requires: &[RequireRecord<AB::Var>],
     ) -> Vec<AB::Expr> {
         match self {
-            LurkChip::Hasher24_8(hasher) => {
+            LurkChip::Hasher3(hasher) => {
                 hasher.eval(builder, is_real, preimg, witness, nonce, requires)
             }
-            LurkChip::Hasher32_8(hasher) => {
+            LurkChip::Hasher4(hasher) => {
                 hasher.eval(builder, is_real, preimg, witness, nonce, requires)
             }
-            LurkChip::Hasher40_8(hasher) => {
+            LurkChip::Hasher5(hasher) => {
                 hasher.eval(builder, is_real, preimg, witness, nonce, requires)
             }
             LurkChip::U64(op) => op.eval(builder, is_real, preimg, witness, nonce, requires),
@@ -155,8 +155,8 @@ pub type LurkHasher = Hasher<BabyBear, LurkChip>;
 #[inline]
 pub fn lurk_hasher() -> LurkHasher {
     Hasher::new(
-        LurkChip::Hasher24_8(PoseidonChipset::default()),
-        LurkChip::Hasher32_8(PoseidonChipset::default()),
-        LurkChip::Hasher40_8(PoseidonChipset::default()),
+        LurkChip::Hasher3(PoseidonChipset::default()),
+        LurkChip::Hasher4(PoseidonChipset::default()),
+        LurkChip::Hasher5(PoseidonChipset::default()),
     )
 }

--- a/src/lurk/cli/comm_data.rs
+++ b/src/lurk/cli/comm_data.rs
@@ -50,7 +50,7 @@ impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     where
         F: Field,
     {
-        ZPtr::comm(zstore.hash24(self.build_preimg()))
+        ZPtr::comm(zstore.hash3(self.build_preimg()))
     }
 
     #[inline]
@@ -58,7 +58,7 @@ impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     where
         F: Field,
     {
-        zstore.hash24(self.build_preimg()); // make zstore aware of this hash
+        zstore.hash3(self.build_preimg()); // make zstore aware of this hash
         self.zdag.populate_zstore(zstore);
     }
 }

--- a/src/lurk/cli/comm_data.rs
+++ b/src/lurk/cli/comm_data.rs
@@ -50,7 +50,7 @@ impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     where
         F: Field,
     {
-        ZPtr::comm(zstore.hash3(self.build_preimg()))
+        ZPtr::comm(zstore.hash24(self.build_preimg()))
     }
 
     #[inline]
@@ -58,7 +58,7 @@ impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     where
         F: Field,
     {
-        zstore.hash3(self.build_preimg()); // make zstore aware of this hash
+        zstore.hash24(self.build_preimg()); // make zstore aware of this hash
         self.zdag.populate_zstore(zstore);
     }
 }

--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -426,7 +426,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         let (&callable, _) = repl.zstore.fetch_tuple2(call_expr);
         match callable.tag {
             Tag::BigNum | Tag::Comm => {
-                let inv_hashes3 = repl.queries.get_inv_queries("hash_24_8", &repl.toplevel);
+                let inv_hashes3 = repl.queries.get_inv_queries("hash3", &repl.toplevel);
                 if !inv_hashes3.contains_key(callable.digest.as_slice()) {
                     // try to fetch a persisted commitment
                     Self::fetch_comm_data(repl, &callable.digest, None)?;
@@ -458,7 +458,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         }
         let (_, next_callable) = repl.zstore.fetch_tuple2(cons);
         if matches!(next_callable.tag, Tag::Comm | Tag::BigNum) {
-            let inv_hashes3 = repl.queries.get_inv_queries("hash_24_8", &repl.toplevel);
+            let inv_hashes3 = repl.queries.get_inv_queries("hash3", &repl.toplevel);
             let preimg = inv_hashes3
                 .get(next_callable.digest.as_slice())
                 .expect("Preimage must be known");

--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -330,7 +330,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         ],
         example: &[
             "!(hide (bignum (commit 123)) 42)",
-            "!(hide #0x3719f5d02845123a80da4f5077c803ba0ce1964e08289a9d020603c1f3c450 42)",
+            "!(hide #0x4a902d7be96d1021a473353bd59247ea4c0f0688b5bae0c833a1f624b77ede 42)",
         ],
         run: |repl, args, _path| {
             let (&secret_expr, &payload_expr) = repl.peek2(args)?;
@@ -388,7 +388,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         info: &[],
         example: &[
             "!(commit 123)",
-            "!(open #0x3719f5d02845123a80da4f5077c803ba0ce1964e08289a9d020603c1f3c450)",
+            "!(open #0x4a902d7be96d1021a473353bd59247ea4c0f0688b5bae0c833a1f624b77ede)",
         ],
         run: |repl, args, _path| {
             let expr = *repl.peek1(args)?;
@@ -407,7 +407,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         info: &[],
         example: &[
             "!(commit 123)",
-            "!(fetch #0x3719f5d02845123a80da4f5077c803ba0ce1964e08289a9d020603c1f3c450)",
+            "!(fetch #0x4a902d7be96d1021a473353bd59247ea4c0f0688b5bae0c833a1f624b77ede)",
         ],
         run: |repl, args, _path| {
             let expr = *repl.peek1(args)?;
@@ -444,7 +444,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         info: &["It's also capable of opening persisted commitments."],
         example: &[
             "(commit (lambda (x) x))",
-            "!(call #0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a 0)",
+            "!(call #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 0)",
         ],
         run: |repl, args, _path| {
             Self::call(repl, args)?;
@@ -483,7 +483,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
                        (let ((counter (+ counter x)))
                          (cons counter (commit (add counter)))))))
                (add 0)))",
-            "!(chain #0x8ef25bc2228ca9799db65fd2b137a7b0ebccbfc04cf8530133e60087d403db 1)",
+            "!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 1)",
         ],
         run: |repl, args, _path| {
             let cons = Self::call(repl, args)?;
@@ -594,9 +594,9 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         example: &[
             "!(defpackage abc)",
             "!(in-package abc)",
-            "!(def two (.lurk.+ 1 1))",
-            "!(in-package .lurk.user)",
-            ".lurk.user.abc.two",
+            "!(def two (.lurk.builtin.+ 1 1))",
+            "!(in-package .lurk-user)",
+            ".lurk-user.abc.two",
         ],
         run: |repl, args, _path| {
             let arg = repl.peek1(args)?;
@@ -936,7 +936,7 @@ impl<H: Chipset<F>> MetaCmd<F, H> {
             "(commit '(13 . 17))",
             "!(prove-protocol my-protocol",
             "  \"protocol-proof\"",
-            "  #0x896994f6258a01fbc7f21a81cb28a537259c3e97cc62da0a2773c63f9b4168",
+            "  #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc",
             "  '(13 . 17))",
         ],
         run: |repl, args, _path| {

--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -269,15 +269,15 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
 
     fn prepare_queries(&mut self) {
         self.queries.clean();
-        let hash_24_8 = std::mem::take(&mut self.zstore.hashes3_diff);
-        let hash_32_8 = std::mem::take(&mut self.zstore.hashes4_diff);
-        let hash_48_8 = std::mem::take(&mut self.zstore.hashes6_diff);
+        let hash_24_8 = std::mem::take(&mut self.zstore.hashes24_diff);
+        let hash_32_8 = std::mem::take(&mut self.zstore.hashes32_diff);
+        let hash_40_8 = std::mem::take(&mut self.zstore.hashes40_diff);
         self.queries
             .inject_inv_queries_owned("hash_24_8", &self.toplevel, hash_24_8);
         self.queries
             .inject_inv_queries_owned("hash_32_8", &self.toplevel, hash_32_8);
         self.queries
-            .inject_inv_queries_owned("hash_48_8", &self.toplevel, hash_48_8);
+            .inject_inv_queries_owned("hash_40_8", &self.toplevel, hash_40_8);
     }
 
     fn build_input(&self, expr: &ZPtr<F>, env: &ZPtr<F>) -> [F; INPUT_SIZE] {
@@ -294,7 +294,7 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
             digest,
             self.queries.get_inv_queries("hash_24_8", &self.toplevel),
             self.queries.get_inv_queries("hash_32_8", &self.toplevel),
-            self.queries.get_inv_queries("hash_48_8", &self.toplevel),
+            self.queries.get_inv_queries("hash_40_8", &self.toplevel),
         )
     }
 

--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -269,15 +269,15 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
 
     fn prepare_queries(&mut self) {
         self.queries.clean();
-        let hash_24_8 = std::mem::take(&mut self.zstore.hashes3_diff);
-        let hash_32_8 = std::mem::take(&mut self.zstore.hashes4_diff);
-        let hash_40_8 = std::mem::take(&mut self.zstore.hashes5_diff);
+        let hashes3 = std::mem::take(&mut self.zstore.hashes3_diff);
+        let hashes4 = std::mem::take(&mut self.zstore.hashes4_diff);
+        let hashes5 = std::mem::take(&mut self.zstore.hashes5_diff);
         self.queries
-            .inject_inv_queries_owned("hash_24_8", &self.toplevel, hash_24_8);
+            .inject_inv_queries_owned("hash3", &self.toplevel, hashes3);
         self.queries
-            .inject_inv_queries_owned("hash_32_8", &self.toplevel, hash_32_8);
+            .inject_inv_queries_owned("hash4", &self.toplevel, hashes4);
         self.queries
-            .inject_inv_queries_owned("hash_40_8", &self.toplevel, hash_40_8);
+            .inject_inv_queries_owned("hash5", &self.toplevel, hashes5);
     }
 
     fn build_input(&self, expr: &ZPtr<F>, env: &ZPtr<F>) -> [F; INPUT_SIZE] {
@@ -292,9 +292,9 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
         self.zstore.memoize_dag(
             tag,
             digest,
-            self.queries.get_inv_queries("hash_24_8", &self.toplevel),
-            self.queries.get_inv_queries("hash_32_8", &self.toplevel),
-            self.queries.get_inv_queries("hash_40_8", &self.toplevel),
+            self.queries.get_inv_queries("hash3", &self.toplevel),
+            self.queries.get_inv_queries("hash4", &self.toplevel),
+            self.queries.get_inv_queries("hash5", &self.toplevel),
         )
     }
 

--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -269,9 +269,9 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
 
     fn prepare_queries(&mut self) {
         self.queries.clean();
-        let hash_24_8 = std::mem::take(&mut self.zstore.hashes24_diff);
-        let hash_32_8 = std::mem::take(&mut self.zstore.hashes32_diff);
-        let hash_40_8 = std::mem::take(&mut self.zstore.hashes40_diff);
+        let hash_24_8 = std::mem::take(&mut self.zstore.hashes3_diff);
+        let hash_32_8 = std::mem::take(&mut self.zstore.hashes4_diff);
+        let hash_40_8 = std::mem::take(&mut self.zstore.hashes5_diff);
         self.queries
             .inject_inv_queries_owned("hash_24_8", &self.toplevel, hash_24_8);
         self.queries

--- a/src/lurk/cli/tests/first.lurk
+++ b/src/lurk/cli/tests/first.lurk
@@ -35,17 +35,17 @@
 ;; test calling functional commitments
 !(call (lambda (x) x) 0)
 !(commit (eval '(lambda (x) x)))
-!(call #0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a 0)
-!(call (comm #0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a) 0)
+!(call #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 0)
+!(call (comm #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc) 0)
 
 ;; test chain and transition
 !(commit (eval '(letrec ((add (lambda (counter x)
                        (let ((counter (+ counter x)))
                          (cons counter (commit (add counter)))))))
                (add 0))))
-!(chain #0x8ef25bc2228ca9799db65fd2b137a7b0ebccbfc04cf8530133e60087d403db 1)
+!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 1)
 
-!(def state0 (cons nil (comm #0x8ef25bc2228ca9799db65fd2b137a7b0ebccbfc04cf8530133e60087d403db)))
+!(def state0 (cons nil (comm #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d)))
 !(transition state1 state0 1)
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))
@@ -59,7 +59,7 @@
                          (cons counter (bignum (commit (add counter))))))))
                (add 0))))
 
-!(def state0 (cons nil #0x5c438d9aaadaaaa1f7ee1a5f3deaa400c29cbf1ab51240e667c1120a5ca0f8))
+!(def state0 (cons nil #0x3782a9f09a9311ba5f9d41718c470ca6e83a1701cb00a90cd0a590b94f3da3))
 !(transition state1 state0 1)
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))
@@ -70,10 +70,10 @@
 ;; test packages
 !(defpackage abc)
 !(in-package abc)
-!(def two (.lurk.+ 1 1))
-!(in-package .lurk.user)
-!(assert-eq .lurk.user.abc.two 2)
-!(import .lurk.user.abc.two)
+!(def two (.lurk.builtin.+ 1 1))
+!(in-package .lurk-user)
+!(assert-eq .lurk-user.abc.two 2)
+!(import .lurk-user.abc.two)
 !(assert-eq two 2)
 
 ;; test dump-expr/load-expr

--- a/src/lurk/cli/tests/mod.rs
+++ b/src/lurk/cli/tests/mod.rs
@@ -10,6 +10,7 @@ fn test_meta_commands() {
     assert!(repl
         .load_file("src/lurk/cli/tests/first.lurk".into(), false)
         .is_ok());
+    let mut repl = Repl::new();
     assert!(repl
         .load_file("src/lurk/cli/tests/second.lurk".into(), false)
         .is_ok());
@@ -24,6 +25,7 @@ fn test_meta_commands_with_proofs() {
     assert!(repl
         .load_file("src/lurk/cli/tests/prove.lurk".into(), false)
         .is_ok());
+    let mut repl = Repl::new();
     assert!(repl
         .load_file("src/lurk/cli/tests/verify.lurk".into(), false)
         .is_ok());

--- a/src/lurk/cli/tests/prove.lurk
+++ b/src/lurk/cli/tests/prove.lurk
@@ -1,5 +1,5 @@
 !(prove (cons 1 2))
-!(verify "5eb9efba6f028b458dbaa0cdb059711342e7f35031de89f5c6c6e5891a3136")
+!(verify "4668bed30416bfbdbb8011df22ff919ececd2607357b77638a1131b395dc23")
 
 !(defprotocol my-protocol (hash pair)
   (cons
@@ -13,7 +13,7 @@
 
 !(prove-protocol my-protocol
   "repl-test-protocol-proof"
-  #0x896994f6258a01fbc7f21a81cb28a537259c3e97cc62da0a2773c63f9b4168
+  #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc
   '(13 . 17))
 
 !(verify-protocol my-protocol "repl-test-protocol-proof")

--- a/src/lurk/cli/tests/second.lurk
+++ b/src/lurk/cli/tests/second.lurk
@@ -1,17 +1,17 @@
 ;; test fetching data from first.lurk
-!(fetch #0x53b1ec7bf5d185b40758f50be7bf7d049775bdfe5a31dbdebfa81810d6752)
-!(assert-eq (open #0x53b1ec7bf5d185b40758f50be7bf7d049775bdfe5a31dbdebfa81810d6752) 42)
+!(fetch #0x77096cf6a7692e3c7e0ddb3bb6e82cf1c2d00d0984be91ce453c91b60b1bcb)
+!(assert-eq (open #0x77096cf6a7692e3c7e0ddb3bb6e82cf1c2d00d0984be91ce453c91b60b1bcb) 42)
 
 ;; test open
-!(open #0x68b44cb79d4d6a771b09e18cc71cc1af9601a359433ee53b20aa27349ab6fb)
-!(assert-eq (open #0x68b44cb79d4d6a771b09e18cc71cc1af9601a359433ee53b20aa27349ab6fb) 42)
+!(open #0x4be65b0be0e53c98cbde4451413f4205573b7cbf51b1778500759407e2cd88)
+!(assert-eq (open #0x4be65b0be0e53c98cbde4451413f4205573b7cbf51b1778500759407e2cd88) 42)
 
 ;; test call/chain
-!(call #0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a 0)
-!(chain #0x8ef25bc2228ca9799db65fd2b137a7b0ebccbfc04cf8530133e60087d403db 1)
+!(call #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 0)
+!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 1)
 
 ;; test transition
-!(def state (cons nil #0x8ef25bc2228ca9799db65fd2b137a7b0ebccbfc04cf8530133e60087d403db))
+!(def state (cons nil #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d))
 !(transition state1 state 1)
 !(assert-eq (car state1) 1)
 

--- a/src/lurk/cli/tests/verify.lurk
+++ b/src/lurk/cli/tests/verify.lurk
@@ -1,4 +1,5 @@
-!(verify "5eb9efba6f028b458dbaa0cdb059711342e7f35031de89f5c6c6e5891a3136")
+!(inspect "4668bed30416bfbdbb8011df22ff919ececd2607357b77638a1131b395dc23")
+!(verify "4668bed30416bfbdbb8011df22ff919ececd2607357b77638a1131b395dc23")
 
 !(load-expr my-protocol "repl-test-protocol")
 !(verify-protocol my-protocol "repl-test-protocol-proof")

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -29,11 +29,11 @@ impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
             .expect("Data missing from ZStore's DAG");
         match zptr_type {
             ZPtrType::Atom => (),
-            ZPtrType::Tuple2(a, b) | ZPtrType::Compact2(a, b) => {
+            ZPtrType::Tuple2(a, b) | ZPtrType::Compact10(a, b) => {
                 self.populate_with(a, zstore, cache);
                 self.populate_with(b, zstore, cache);
             }
-            ZPtrType::Tuple3(a, b, c) | ZPtrType::Compact3(a, b, c) => {
+            ZPtrType::Compact110(a, b, c) => {
                 self.populate_with(a, zstore, cache);
                 self.populate_with(b, zstore, cache);
                 self.populate_with(c, zstore, cache);
@@ -66,20 +66,19 @@ impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
             match &zptr_type {
                 ZPtrType::Atom => (),
                 ZPtrType::Tuple2(a, b) => {
-                    zstore.hashes4.insert(ZPtr::flatten2(a, b), zptr.digest);
+                    let preimg = ZPtr::flatten2(a, b);
+                    zstore.hashes32.insert(preimg, zptr.digest);
+                    zstore.hashes32_diff.insert(preimg, zptr.digest);
                 }
-                ZPtrType::Tuple3(a, b, c) => {
-                    zstore.hashes6.insert(ZPtr::flatten3(a, b, c), zptr.digest);
+                ZPtrType::Compact10(a, b) => {
+                    let preimg = ZPtr::flatten_compact10(a, b);
+                    zstore.hashes24.insert(preimg, zptr.digest);
+                    zstore.hashes24_diff.insert(preimg, zptr.digest);
                 }
-                ZPtrType::Compact2(a, b) => {
-                    zstore
-                        .hashes3
-                        .insert(ZPtr::flatten_compact2(a, b), zptr.digest);
-                }
-                ZPtrType::Compact3(a, b, c) => {
-                    zstore
-                        .hashes4
-                        .insert(ZPtr::flatten_compact3(a, b, c), zptr.digest);
+                ZPtrType::Compact110(a, b, c) => {
+                    let preimg = ZPtr::flatten_compact110(a, b, c);
+                    zstore.hashes40.insert(preimg, zptr.digest);
+                    zstore.hashes40_diff.insert(preimg, zptr.digest);
                 }
             }
             zstore.dag.insert(zptr, zptr_type);

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -67,18 +67,18 @@ impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
                 ZPtrType::Atom => (),
                 ZPtrType::Tuple2(a, b) => {
                     let preimg = ZPtr::flatten2(a, b);
-                    zstore.hashes32.insert(preimg, zptr.digest);
-                    zstore.hashes32_diff.insert(preimg, zptr.digest);
+                    zstore.hashes4.insert(preimg, zptr.digest);
+                    zstore.hashes4_diff.insert(preimg, zptr.digest);
                 }
                 ZPtrType::Compact10(a, b) => {
                     let preimg = ZPtr::flatten_compact10(a, b);
-                    zstore.hashes24.insert(preimg, zptr.digest);
-                    zstore.hashes24_diff.insert(preimg, zptr.digest);
+                    zstore.hashes3.insert(preimg, zptr.digest);
+                    zstore.hashes3_diff.insert(preimg, zptr.digest);
                 }
                 ZPtrType::Compact110(a, b, c) => {
                     let preimg = ZPtr::flatten_compact110(a, b, c);
-                    zstore.hashes40.insert(preimg, zptr.digest);
-                    zstore.hashes40_diff.insert(preimg, zptr.digest);
+                    zstore.hashes5.insert(preimg, zptr.digest);
+                    zstore.hashes5_diff.insert(preimg, zptr.digest);
                 }
             }
             zstore.dag.insert(zptr, zptr_type);

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1920,7 +1920,7 @@ mod test {
             let digest: List<_> = digest.into();
 
             let mut queries = QueryRecord::new(toplevel);
-            queries.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
+            queries.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
             let mut ingress_args = [F::zero(); 16];
             ingress_args[0] = tag;

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1,4 +1,4 @@
-use indexmap::{map::Iter, IndexMap};
+use indexmap::IndexMap;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use p3_baby_bear::BabyBear;
@@ -8,7 +8,7 @@ use rustc_hash::FxBuildHasher;
 use crate::{
     func,
     lair::{
-        expr::{BlockE, CasesE, CtrlE, FuncE, OpE, Var},
+        expr::{BlockE, CtrlE, FuncE, OpE, Var},
         toplevel::Toplevel,
         List, Name,
     },
@@ -16,82 +16,91 @@ use crate::{
 
 use super::{
     chipset::{lurk_chip_map, LurkChip},
-    state::{State, StateRcCell, LURK_PACKAGE_SYMBOLS_NAMES},
+    state::{builtin_sym, lurk_sym, BUILTIN_SYMBOLS, LURK_SYMBOLS},
     tag::Tag,
-    zstore::{lurk_zstore, ZStore},
+    zstore::{lurk_zstore, ZStore, DIGEST_SIZE},
 };
 
-pub struct BuiltinIndex(usize);
+pub struct DigestIndex(usize);
 
-impl BuiltinIndex {
+impl DigestIndex {
     fn to_field<F: AbstractField>(&self) -> F {
         F::from_canonical_usize(self.0)
     }
 }
 
-pub struct BuiltinMemo<'a, F>(IndexMap<&'a str, List<F>, FxBuildHasher>);
-
-impl<'a> BuiltinMemo<'a, BabyBear> {
-    fn new(state: &StateRcCell, zstore: &mut ZStore<BabyBear, LurkChip>) -> Self {
-        Self(
-            LURK_PACKAGE_SYMBOLS_NAMES
-                .into_iter()
-                .filter(|sym| sym != &"nil")
-                .map(|name| {
-                    (
-                        name,
-                        zstore
-                            .read_with_state(state.clone(), name)
-                            .unwrap()
-                            .digest
-                            .into(),
-                    )
-                })
-                .collect(),
-        )
+struct TagNil;
+impl TagNil {
+    fn to_field<F: AbstractField>(&self) -> F {
+        F::zero()
     }
 }
 
-impl<'a, F> BuiltinMemo<'a, F> {
-    fn index(&self, builtin: &'a str) -> BuiltinIndex {
-        BuiltinIndex(self.0.get_index_of(builtin).expect("Unknown builtin"))
+pub struct TagT;
+impl TagT {
+    fn to_field<F: AbstractField>(&self) -> F {
+        F::one()
+    }
+}
+
+pub struct Digests<'a, F>(IndexMap<&'a str, List<F>, FxBuildHasher>);
+
+impl<'a> Digests<'a, BabyBear> {
+    fn new(zstore: &mut ZStore<BabyBear, LurkChip>) -> Self {
+        let mut map = IndexMap::default();
+        for name in LURK_SYMBOLS {
+            let zptr = zstore.intern_symbol(&lurk_sym(name));
+            assert_eq!(zptr.tag, Tag::Sym);
+            map.insert(name, zptr.digest.into());
+        }
+        for name in BUILTIN_SYMBOLS {
+            let zptr = zstore.intern_symbol(&builtin_sym(name));
+            assert_eq!(zptr.tag, Tag::Builtin);
+            map.insert(name, zptr.digest.into());
+        }
+        Self(map)
+    }
+}
+
+impl<'a, F> Digests<'a, F> {
+    fn ptr(&self, name: &'a str) -> DigestIndex {
+        // + 1 because available memory starts from 1 (0 is reserved)
+        DigestIndex(self.0.get_index_of(name).expect("Unknown symbol name") + 1)
     }
 
-    fn iter(&self) -> Iter<'_, &str, Box<[F]>> {
-        self.0.iter()
+    fn digest(&self, name: &'a str) -> &List<F> {
+        self.0.get(name).expect("Unknown symbol name")
     }
 }
 
 /// Creates a `Toplevel` with the functions used for Lurk evaluation, also returning
-/// a `ZStore` with the Lurk builtins already interned.
+/// a `ZStore` with the Lurk symbols already interned.
 #[inline]
 pub fn build_lurk_toplevel() -> (Toplevel<BabyBear, LurkChip>, ZStore<BabyBear, LurkChip>) {
-    let state = State::init_lurk_state().rccell();
     let mut zstore = lurk_zstore();
-    let builtins = BuiltinMemo::new(&state, &mut zstore);
-    let nil = zstore.read_with_state(state, "nil").unwrap().digest.into();
+    let digests = Digests::new(&mut zstore);
     let funcs = &[
         lurk_main(),
-        eval(&builtins),
-        eval_opening_unop(&builtins),
+        preallocate_symbols(&digests),
+        eval(),
+        eval_builtin_expr(&digests),
+        eval_opening_unop(&digests),
         eval_hide(),
-        eval_unop(&builtins),
-        eval_binop_num(&builtins),
-        eval_binop_misc(&builtins),
+        eval_unop(&digests),
+        eval_binop_num(&digests),
+        eval_binop_misc(&digests),
         eval_begin(),
         eval_list(),
         open_comm(),
-        equal(&builtins),
+        equal(&digests),
         equal_inner(),
-        car_cdr(),
+        car_cdr(&digests),
         eval_let(),
         eval_letrec(),
         apply(),
         env_lookup(),
-        ingress(),
-        ingress_builtin(&builtins),
-        egress(nil),
-        egress_builtin(&builtins),
+        ingress(&digests),
+        egress(&digests),
         hash_24_8(),
         hash_32_8(),
         hash_48_8(),
@@ -114,6 +123,7 @@ pub fn build_lurk_toplevel() -> (Toplevel<BabyBear, LurkChip>, ZStore<BabyBear, 
 pub enum EvalErr {
     UnboundVar = 0,
     InvalidForm,
+    IllegalBindingVar,
     ApplyNonFunc,
     ParamsNotList,
     ParamNotSymbol,
@@ -124,7 +134,6 @@ pub enum EvalErr {
     NotChar,
     NotCons,
     NotString,
-    NonConstantBuiltin,
     NotU64,
     NotBigNum,
     CantOpen,
@@ -147,27 +156,53 @@ impl EvalErr {
 pub fn lurk_main<F: AbstractField>() -> FuncE<F> {
     func!(
         partial fn lurk_main(full_expr_tag: [8], expr_digest: [8], env_digest: [8]): [16] {
+            let _foo: [0] = call(preallocate_symbols,); // TODO: replace by `exec`
             // Ingress on expr
-            let expr = call(ingress, full_expr_tag, expr_digest);
+            let (expr_tag, expr) = call(ingress, full_expr_tag, expr_digest);
             // Ingress on env
             let padding = [0; 7];
             let env_tag = Tag::Env;
             let full_env_tag: [8] = (env_tag, padding);
-            let env = call(ingress, full_env_tag, env_digest);
+            let (_env_tag, env) = call(ingress, full_env_tag, env_digest);
             // Evaluate expr, env
-            let (expr_tag, _rest: [7]) = full_expr_tag;
             let (val_tag, val) = call(eval, expr_tag, expr, env);
             // Egress on val
-            let val_digest: [8] = call(egress, val_tag, val);
+            let (val_tag, val_digest: [8]) = call(egress, val_tag, val);
             let full_val_tag: [8] = (val_tag, padding);
             return (full_val_tag, val_digest)
         }
     )
 }
 
-pub fn ingress<F: AbstractField + Ord>() -> FuncE<F> {
+pub fn preallocate_symbols<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
+    let mut ops = Vec::with_capacity(2 * digests.0.len());
+    let arr_var = Var {
+        name: "arr",
+        size: DIGEST_SIZE,
+    };
+    let ptr_var = Var {
+        name: "_ptr",
+        size: 1,
+    };
+    for digest in digests.0.values() {
+        ops.push(OpE::Array(arr_var, digest.clone()));
+        ops.push(OpE::Store(ptr_var, [arr_var].into())); // TODO: replace by `Preallocate(digest.clone())`
+    }
+    let ops = ops.into();
+    let ctrl = CtrlE::Return([].into()); // TODO: replace by `Exit`
+    FuncE {
+        name: Name("preallocate_symbols"),
+        invertible: false,
+        partial: false,
+        input_params: [].into(),
+        output_size: 0,
+        body: BlockE { ops, ctrl },
+    }
+}
+
+pub fn ingress<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
-        fn ingress(tag_full: [8], digest: [8]): [1] {
+        fn ingress(tag_full: [8], digest: [8]): [2] {
             let zeros = [0; 7];
             let (tag, rest: [7]) = tag_full;
             assert_eq!(rest, zeros);
@@ -175,11 +210,7 @@ pub fn ingress<F: AbstractField + Ord>() -> FuncE<F> {
                 Tag::Num => {
                     let (x, rest: [7]) = digest;
                     assert_eq!(rest, zeros);
-                    return x
-                }
-                Tag::Nil => {
-                    let zero = 0;
-                    return zero
+                    return (tag, x)
                 }
                 Tag::Char => {
                     let (bytes: [4], rest: [4]) = digest;
@@ -187,70 +218,78 @@ pub fn ingress<F: AbstractField + Ord>() -> FuncE<F> {
                     let zeros = [0; 4];
                     assert_eq!(rest, zeros);
                     let ptr = store(bytes);
-                    return ptr
+                    return (tag, ptr)
                 }
                 Tag::U64 => {
                     range_u8!(digest);
                     let ptr = store(digest);
-                    return ptr
+                    return (tag, ptr)
                 }
-                Tag::Sym, Tag::Key, Tag::BigNum, Tag::Comm => {
+                Tag::Sym => {
+                    let nil_digest = Array(digests.digest("nil").clone());
+                    let not_nil = sub(digest, nil_digest);
+                    if !not_nil {
+                        let nil_tag = TagNil;
+                        let ptr = digests.ptr("nil");
+                        return (nil_tag, ptr)
+                    }
+                    let t_digest = Array(digests.digest("t").clone());
+                    let not_t = sub(digest, t_digest);
+                    if !not_t {
+                        let t_tag = TagT;
+                        let ptr = digests.ptr("t");
+                        return (t_tag, ptr)
+                    }
                     let ptr = store(digest);
-                    return ptr
+                    return (tag, ptr)
                 }
-                Tag::Builtin => {
-                    let idx = call(ingress_builtin, digest);
-                    return idx
+                Tag::Builtin, Tag::Key, Tag::BigNum, Tag::Comm => {
+                    let ptr = store(digest);
+                    return (tag, ptr)
                 }
                 Tag::Str => {
                     if !digest {
                         let zero = 0;
-                        return zero
+                        return (tag, zero)
                     }
                     let (fst_tag_full: [8], fst_digest: [8],
                          snd_tag_full: [8], snd_digest: [8]) = preimg(hash_32_8, digest);
-                    let fst_ptr = call(ingress, fst_tag_full, fst_digest);
-                    let snd_ptr = call(ingress, snd_tag_full, snd_digest);
-                    let (fst_tag, _rest: [7]) = fst_tag_full;
-                    let (snd_tag, _rest: [7]) = snd_tag_full;
+                    let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
+                    let (snd_tag, snd_ptr) = call(ingress, snd_tag_full, snd_digest);
                     let ptr = store(fst_tag, fst_ptr, snd_tag, snd_ptr);
-                    return ptr
+                    return (tag, ptr)
                 }
                 Tag::Cons => {
                     let (fst_tag_full: [8], fst_digest: [8],
                          snd_tag_full: [8], snd_digest: [8]) = preimg(hash_32_8, digest);
-                    let fst_ptr = call(ingress, fst_tag_full, fst_digest);
-                    let snd_ptr = call(ingress, snd_tag_full, snd_digest);
-                    let (fst_tag, _rest: [7]) = fst_tag_full;
-                    let (snd_tag, _rest: [7]) = snd_tag_full;
+                    let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
+                    let (snd_tag, snd_ptr) = call(ingress, snd_tag_full, snd_digest);
                     let ptr = store(fst_tag, fst_ptr, snd_tag, snd_ptr);
-                    return ptr
+                    return (tag, ptr)
                 }
                 Tag::Thunk => {
                     let (fst_tag, padding: [7], fst_digest: [8], snd_digest: [8]) = preimg(hash_24_8, digest);
                     assert_eq!(padding, zeros);
                     let env_tag = Tag::Env;
-                    let fst_ptr = call(ingress, fst_tag, padding, fst_digest);
-                    let snd_ptr = call(ingress, env_tag, padding, snd_digest);
+                    let (fst_tag, fst_ptr) = call(ingress, fst_tag, padding, fst_digest);
+                    let (_snd_tag, snd_ptr) = call(ingress, env_tag, padding, snd_digest);
                     let ptr = store(fst_tag, fst_ptr, snd_ptr);
-                    return ptr
+                    return (tag, ptr)
                 }
                 Tag::Fun => {
                     let (fst_tag_full: [8], fst_digest: [8],
                          snd_tag_full: [8], snd_digest: [8],
                          trd_tag_full: [8], trd_digest: [8]) = preimg(hash_48_8, digest);
-                    let fst_ptr = call(ingress, fst_tag_full, fst_digest);
-                    let snd_ptr = call(ingress, snd_tag_full, snd_digest);
-                    let trd_ptr = call(ingress, trd_tag_full, trd_digest);
-                    let (fst_tag, _rest: [7]) = fst_tag_full;
-                    let (snd_tag, _rest: [7]) = snd_tag_full;
+                    let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
+                    let (snd_tag, snd_ptr) = call(ingress, snd_tag_full, snd_digest);
+                    let (_trd_tag, trd_ptr) = call(ingress, trd_tag_full, trd_digest);
                     let ptr = store(fst_tag, fst_ptr, snd_tag, snd_ptr, trd_ptr);
-                    return ptr
+                    return (tag, ptr)
                 }
                 Tag::Env => {
                     if !digest {
                         let zero = 0;
-                        return zero
+                        return (tag, zero)
                     }
                     let (sym_digest: [8],
                          val_tag, padding: [7],
@@ -259,184 +298,116 @@ pub fn ingress<F: AbstractField + Ord>() -> FuncE<F> {
                     assert_eq!(padding, zeros);
                     let sym_tag = Tag::Sym;
                     let env_tag = Tag::Env;
-                    let sym_ptr = call(ingress, sym_tag, padding, sym_digest);
-                    let val_ptr = call(ingress, val_tag, padding, val_digest);
-                    let env_ptr = call(ingress, env_tag, padding, env_digest);
+                    let (_sym_tag, sym_ptr) = call(ingress, sym_tag, padding, sym_digest);
+                    let (val_tag, val_ptr) = call(ingress, val_tag, padding, val_digest);
+                    let (_env_tag, env_ptr) = call(ingress, env_tag, padding, env_digest);
                     let ptr = store(sym_ptr, val_tag, val_ptr, env_ptr);
-                    return ptr
+                    return (tag, ptr)
                 }
             }
         }
     )
 }
 
-fn ingress_builtin<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
-    let input_var = Var {
-        name: "digest",
-        size: 8,
-    };
-    let ret_var = Var {
-        name: "res",
-        size: 1,
-    };
-    let branch = |i: usize| BlockE {
-        ops: [OpE::Const(ret_var, F::from_canonical_usize(i))].into(),
-        ctrl: CtrlE::<F>::Return([ret_var].into()),
-    };
-    let branches = builtins
-        .iter()
-        .enumerate()
-        .map(|(i, (_, digest))| (digest.clone(), branch(i)))
-        .collect();
-    let cases = CasesE {
-        branches,
-        default: None,
-    };
-    let ops = [].into();
-    let ctrl = CtrlE::<F>::MatchMany(input_var, cases);
-
-    FuncE {
-        name: Name("ingress_builtin"),
-        invertible: false,
-        partial: false,
-        input_params: [input_var].into(),
-        output_size: 1,
-        body: BlockE { ops, ctrl },
-    }
-}
-
-pub fn egress<F: AbstractField + Ord>(nil: List<F>) -> FuncE<F> {
+pub fn egress<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
-        fn egress(tag, val): [8] {
+        fn egress(tag, val): [9] {
             match tag {
                 Tag::Num, Tag::Err => {
                     let padding = [0; 7];
                     let digest: [8] = (val, padding);
-                    return digest
-                }
-                Tag::Nil => {
-                    let digest = Array(nil);
-                    return digest
+                    return (tag, digest)
                 }
                 Tag::Char => {
                     let padding = [0; 4];
                     let bytes: [4] = load(val);
-                    return (bytes, padding)
+                    return (tag, bytes, padding)
                 }
-                Tag::Sym, Tag::Key, Tag::U64, Tag::BigNum, Tag::Comm => {
+                TagNil => {
+                    let sym_tag = Tag::Sym;
+                    let digest = Array(digests.digest("nil").clone());
+                    return (sym_tag, digest)
+                }
+                TagT => {
+                    let sym_tag = Tag::Sym;
+                    let digest = Array(digests.digest("t").clone());
+                    return (sym_tag, digest)
+                }
+                Tag::Sym, Tag::Builtin, Tag::Key, Tag::U64, Tag::BigNum, Tag::Comm => {
                     let digest: [8] = load(val);
-                    return digest
-                }
-                Tag::Builtin => {
-                    let digest: [8] = call(egress_builtin, val);
-                    return digest
+                    return (tag, digest)
                 }
                 Tag::Str => {
                     if !val {
                         let digest = [0; 8];
-                        return digest
+                        return (tag, digest)
                     }
                     let (fst_tag, fst_ptr, snd_tag, snd_ptr) = load(val);
-                    let fst_digest: [8] = call(egress, fst_tag, fst_ptr);
-                    let snd_digest: [8] = call(egress, snd_tag, snd_ptr);
+                    let (fst_tag, fst_digest: [8]) = call(egress, fst_tag, fst_ptr);
+                    let (snd_tag, snd_digest: [8]) = call(egress, snd_tag, snd_ptr);
 
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
                     let snd_tag_full: [8] = (snd_tag, padding);
                     let digest: [8] = call(hash_32_8, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
-                    return digest
+                    return (tag, digest)
                 }
                 Tag::Cons => {
                     let (fst_tag, fst_ptr, snd_tag, snd_ptr) = load(val);
-                    let fst_digest: [8] = call(egress, fst_tag, fst_ptr);
-                    let snd_digest: [8] = call(egress, snd_tag, snd_ptr);
+                    let (fst_tag, fst_digest: [8]) = call(egress, fst_tag, fst_ptr);
+                    let (snd_tag, snd_digest: [8]) = call(egress, snd_tag, snd_ptr);
 
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
                     let snd_tag_full: [8] = (snd_tag, padding);
                     let digest: [8] = call(hash_32_8, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
-                    return digest
+                    return (tag, digest)
                 }
                 Tag::Thunk => {
                     let (fst_tag, fst_ptr, snd_ptr) = load(val);
                     let snd_tag = Tag::Env;
-                    let fst_digest: [8] = call(egress, fst_tag, fst_ptr);
-                    let snd_digest: [8] = call(egress, snd_tag, snd_ptr);
+                    let (fst_tag, fst_digest: [8]) = call(egress, fst_tag, fst_ptr);
+                    let (_snd_tag, snd_digest: [8]) = call(egress, snd_tag, snd_ptr);
 
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
                     let digest: [8] = call(hash_24_8, fst_tag_full, fst_digest, snd_digest);
-                    return digest
+                    return (tag, digest)
                 }
                 Tag::Fun => {
                     let (fst_tag, fst_ptr, snd_tag, snd_ptr, trd_ptr) = load(val);
                     let trd_tag = Tag::Env;
-                    let fst_digest: [8] = call(egress, fst_tag, fst_ptr);
-                    let snd_digest: [8] = call(egress, snd_tag, snd_ptr);
-                    let trd_digest: [8] = call(egress, trd_tag, trd_ptr);
+                    let (fst_tag, fst_digest: [8]) = call(egress, fst_tag, fst_ptr);
+                    let (snd_tag, snd_digest: [8]) = call(egress, snd_tag, snd_ptr);
+                    let (trd_tag, trd_digest: [8]) = call(egress, trd_tag, trd_ptr);
 
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
                     let snd_tag_full: [8] = (snd_tag, padding);
                     let trd_tag_full: [8] = (trd_tag, padding);
                     let digest: [8] = call(hash_48_8, fst_tag_full, fst_digest, snd_tag_full, snd_digest, trd_tag_full, trd_digest);
-                    return digest
+                    return (tag, digest)
                 }
                 Tag::Env => {
                     if !val {
                         let digest = [0; 8];
-                        return digest
+                        return (tag, digest)
                     }
                     let (sym_ptr, val_tag, val_ptr, env_ptr) = load(val);
                     let sym_tag = Tag::Sym;
                     let env_tag = Tag::Env;
-                    let sym_digest: [8] = call(egress, sym_tag, sym_ptr);
-                    let val_digest: [8] = call(egress, val_tag, val_ptr);
-                    let env_digest: [8] = call(egress, env_tag, env_ptr);
+                    let (_sym_tag, sym_digest: [8]) = call(egress, sym_tag, sym_ptr);
+                    let (val_tag, val_digest: [8]) = call(egress, val_tag, val_ptr);
+                    let (_env_tag, env_digest: [8]) = call(egress, env_tag, env_ptr);
 
                     let padding = [0; 7];
                     let val_tag_full: [8] = (val_tag, padding);
                     let digest: [8] = call(hash_32_8, sym_digest, val_tag_full, val_digest, env_digest);
-                    return digest
+                    return (tag, digest)
                 }
             }
         }
     )
-}
-
-fn egress_builtin<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
-    let input_var = Var {
-        name: "val",
-        size: 1,
-    };
-    let ret_var = Var {
-        name: "digest",
-        size: 8,
-    };
-    let branch = |arr: List<F>| BlockE {
-        ops: [OpE::Array(ret_var, arr)].into(),
-        ctrl: CtrlE::<F>::Return([ret_var].into()),
-    };
-    let branches = builtins
-        .iter()
-        .enumerate()
-        .map(|(i, (_, digest))| ([F::from_canonical_usize(i)].into(), branch(digest.clone())))
-        .collect();
-    let cases = CasesE {
-        branches,
-        default: None,
-    };
-    let ops = [].into();
-    let ctrl = CtrlE::<F>::Match(input_var, cases);
-
-    FuncE {
-        name: Name("egress_builtin"),
-        invertible: false,
-        partial: false,
-        input_params: [input_var].into(),
-        output_size: 8,
-        body: BlockE { ops, ctrl },
-    }
 }
 
 pub fn hash_24_8<F>() -> FuncE<F> {
@@ -564,26 +535,11 @@ pub fn big_num_lessthan<F>() -> FuncE<F> {
     )
 }
 
-pub fn eval<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
+pub fn eval<F: AbstractField + Ord>() -> FuncE<F> {
     func!(
         partial fn eval(expr_tag, expr, env): [2] {
-            // Constants, tags, etc
-            let t = builtins.index("t");
-            let nil_tag = Tag::Nil;
-            let cons_tag = Tag::Cons;
-            let err_tag = Tag::Err;
-            let invalid_form = EvalErr::InvalidForm;
-
             match expr_tag {
-                Tag::Builtin => {
-                    let not_t = sub(expr, t);
-                    if !not_t {
-                        return (expr_tag, expr)
-                    }
-                    let non_constant_builtin = EvalErr::NonConstantBuiltin;
-                    return (err_tag, non_constant_builtin)
-                }
-                Tag::Sym => {
+                Tag::Builtin, Tag::Sym => {
                     let expr_digest: [8] = load(expr);
                     let (res_tag, res) = call(env_lookup, expr_digest, env);
                     match res_tag {
@@ -604,277 +560,8 @@ pub fn eval<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
                     let (head_tag, head, rest_tag, rest) = load(expr);
                     match head_tag {
                         Tag::Builtin => {
-                            match head [|sym| builtins.index(sym).to_field()] {
-                                "let", "letrec", "lambda", "cons", "strcons", "type-eq", "type-eqq" => {
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (fst_tag, fst, rest_tag, rest) = load(rest);
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (snd_tag, snd, rest_tag, _rest) = load(rest);
-                                    let rest_not_nil = sub(rest_tag, nil_tag);
-                                    if rest_not_nil {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    match head [|sym| builtins.index(sym).to_field()] {
-                                        "let" => {
-                                            // first element: let symbol
-                                            // second element: binding list
-                                            // third element: body
-                                            let (res_tag, res) = call(eval_let, fst_tag, fst, snd_tag, snd, env);
-                                            return (res_tag, res)
-                                        }
-                                        "letrec" => {
-                                            // analogous to `let`
-                                            let (res_tag, res) = call(eval_letrec, fst_tag, fst, snd_tag, snd, env);
-                                            return (res_tag, res)
-                                        }
-                                        "lambda" => {
-                                            // first element: lambda symbol
-                                            // second element: parameter list
-                                            // third element: body
-                                            // A function (more precisely, a closure) is an object with a
-                                            // parameter list, a body and an environment
-                                            let res_tag = Tag::Fun;
-                                            let res = store(fst_tag, fst, snd_tag, snd, env);
-                                            return (res_tag, res)
-                                        }
-                                        "cons", "strcons" => {
-                                            let (res_tag, res) = call(eval_binop_misc, head, fst_tag, fst, snd_tag, snd, env);
-                                            return (res_tag, res)
-                                        }
-                                        "type-eq" => {
-                                            let (fst_tag, fst) = call(eval, fst_tag, fst, env);
-                                            match fst_tag {
-                                                Tag::Err => {
-                                                    return (fst_tag, fst)
-                                                }
-                                            };
-                                            let (snd_tag, snd) = call(eval, snd_tag, snd, env);
-                                            match snd_tag {
-                                                Tag::Err => {
-                                                    return (snd_tag, snd)
-                                                }
-                                            };
-                                            let type_not_eq = sub(fst_tag, snd_tag);
-                                            if type_not_eq {
-                                                let nil = 0;
-                                                return (nil_tag, nil)
-                                            }
-                                            return (head_tag, t) // head_tag is Tag::Builtin
-                                        }
-                                        "type-eqq" => {
-                                            let (snd_tag, snd) = call(eval, snd_tag, snd, env);
-                                            match snd_tag {
-                                                Tag::Err => {
-                                                    return (snd_tag, snd)
-                                                }
-                                            };
-                                            let type_not_eqq = sub(fst_tag, snd_tag);
-                                            if type_not_eqq {
-                                                let nil = 0;
-                                                return (nil_tag, nil)
-                                            }
-                                            return (head_tag, t) // head_tag is Tag::Builtin
-                                        }
-                                    }
-                                }
-                                "list" => {
-                                    let (expr_tag, expr) = call(eval_list, rest_tag, rest, env);
-                                    return (expr_tag, expr)
-                                }
-                                "+", "-", "*", "/", "%", "=", "<", ">", "<=", ">=" => {
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (fst_tag, fst, rest_tag, rest) = load(rest);
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (snd_tag, snd, rest_tag, _rest) = load(rest);
-                                    let rest_not_nil = sub(rest_tag, nil_tag);
-                                    if rest_not_nil {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (res_tag, res) = call(eval_binop_num, head, fst_tag, fst, snd_tag, snd, env);
-                                    return (res_tag, res)
-                                }
-                                "eval" => {
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (expr_tag, expr, rest_tag, rest) = load(rest);
-                                    match rest_tag {
-                                        Tag::Nil => {
-                                            // Eval must be called twice, first with the original env and then
-                                            // with an empty env
-                                            let (res_tag, res) = call(eval, expr_tag, expr, env);
-                                            match res_tag {
-                                                Tag::Err => {
-                                                    return (res_tag, res)
-                                                }
-                                            };
-                                            let env = 0;
-                                            let (res_tag, res) = call(eval, res_tag, res, env);
-                                            return (res_tag, res)
-                                        }
-                                        Tag::Cons => {
-                                            let (env_expr_tag, env_expr, rest_tag, _rest) = load(rest);
-                                            let rest_not_nil = sub(rest_tag, nil_tag);
-                                            if rest_not_nil {
-                                                return (err_tag, invalid_form)
-                                            }
-                                            let (res_tag, res) = call(eval, expr_tag, expr, env);
-                                            match res_tag {
-                                                Tag::Err => {
-                                                    return (res_tag, res)
-                                                }
-                                            };
-                                            let (env_tag, new_env) = call(eval, env_expr_tag, env_expr, env);
-                                            match env_tag {
-                                                Tag::Err => {
-                                                    return (env_tag, new_env)
-                                                }
-                                                Tag::Env => {
-                                                    let (res_tag, res) = call(eval, res_tag, res, new_env);
-                                                    return (res_tag, res)
-                                                }
-                                            };
-                                            let err = EvalErr::NotEnv;
-                                            return (err_tag, err)
-                                        }
-                                    };
-                                    let not_env = EvalErr::NotEnv;
-                                    return (err_tag, not_env)
-                                }
-                                "quote" => {
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (expr_tag, expr, rest_tag, _rest) = load(rest);
-                                    let rest_not_nil = sub(rest_tag, nil_tag);
-                                    if rest_not_nil {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    return (expr_tag, expr)
-                                }
-                                "begin" => {
-                                    let (expr_tag, expr) = call(eval_begin, rest_tag, rest, env);
-                                    return (expr_tag, expr)
-                                }
-                                "current-env", "empty-env" => {
-                                    let rest_not_nil = sub(rest_tag, nil_tag);
-                                    if rest_not_nil {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let env_tag = Tag::Env;
-                                    match head [|sym| builtins.index(sym).to_field()] {
-                                        "current-env" => {
-                                            return (env_tag, env)
-                                        }
-                                        "empty-env" => {
-                                            let env = 0;
-                                            return (env_tag, env)
-                                        }
-                                    }
-                                }
-                                "breakpoint" => {
-                                    breakpoint;
-                                    match rest_tag {
-                                        Tag::Nil => {
-                                            let nil = 0;
-                                            return (nil_tag, nil)
-                                        }
-                                        Tag::Cons => {
-                                            let (expr_tag, expr, rest_tag, _rest) = load(rest);
-                                            let rest_not_nil = sub(rest_tag, nil_tag);
-                                            if rest_not_nil {
-                                                return (err_tag, invalid_form)
-                                            }
-                                            let (val_tag, val) = call(eval, expr_tag, expr, env);
-                                            return (val_tag, val)
-                                        }
-                                    }
-                                }
-                                "if" => {
-                                    // An if expression is a list of 3 or 4 elements
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (expr_tag, expr, rest_tag, rest) = load(rest);
-                                    let rest_not_cons = sub(rest_tag, cons_tag);
-                                    if rest_not_cons {
-                                        return (err_tag, invalid_form)
-                                    }
-                                    let (t_branch_tag, t_branch, rest_tag, rest) = load(rest);
-                                    match rest_tag {
-                                        Tag::Nil => {
-                                            let (val_tag, val) = call(eval, expr_tag, expr, env);
-                                            match val_tag {
-                                                Tag::Nil, Tag::Err => {
-                                                    return (val_tag, val)
-                                                }
-                                            };
-                                            let (res_tag, res) = call(eval, t_branch_tag, t_branch, env);
-                                            return (res_tag, res)
-                                        }
-                                        Tag::Cons => {
-                                            let (f_branch_tag, f_branch, rest_tag, _rest) = load(rest);
-                                            let rest_not_nil = sub(rest_tag, nil_tag);
-                                            if rest_not_nil {
-                                                return (err_tag, invalid_form)
-                                            }
-                                            let (val_tag, val) = call(eval, expr_tag, expr, env);
-                                            match val_tag {
-                                                Tag::Nil => {
-                                                    let (res_tag, res) = call(eval, f_branch_tag, f_branch, env);
-                                                    return (res_tag, res)
-                                                }
-                                                Tag::Err => {
-                                                    return (val_tag, val)
-                                                }
-                                            };
-                                            let (res_tag, res) = call(eval, t_branch_tag, t_branch, env);
-                                            return (res_tag, res)
-                                        }
-                                    };
-                                    return (err_tag, invalid_form)
-                                }
-                                "eq" => {
-                                    let res: [2] = call(equal, rest_tag, rest, env);
-                                    return res
-                                }
-                                "hide" => {
-                                    let (res_tag, res) = call(eval_hide, rest_tag, rest, env);
-                                    return (res_tag, res)
-                                }
-                                "car" => {
-                                    let (car_tag, car, _cdr_tag, _cdr) = call(car_cdr, rest_tag, rest, env);
-                                    return (car_tag, car)
-                                }
-                                "cdr" => {
-                                    let (_car_tag, _car, cdr_tag, cdr) = call(car_cdr, rest_tag, rest, env);
-                                    return (cdr_tag, cdr)
-                                }
-                                "u64", "char", "atom", "emit", "bignum", "comm" => {
-                                    let (res_tag, res) = call(eval_unop, head, rest_tag, rest, env);
-                                    return (res_tag, res)
-                                }
-                                "commit", "open", "secret" => {
-                                    let (res_tag, res) = call(eval_opening_unop, head, rest_tag, rest, env);
-                                    return (res_tag, res)
-                                }
-                                // TODO: other builtins
-                            }
+                            let (res_tag, res) = call(eval_builtin_expr, head, rest_tag, rest, env);
+                            return (res_tag, res)
                         }
                     };
                     let (head_tag, head) = call(eval, head_tag, head, env);
@@ -897,22 +584,311 @@ pub fn eval<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
     )
 }
 
+pub fn eval_builtin_expr<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
+    func!(
+        partial fn eval_builtin_expr(head, rest_tag, rest, env): [2] {
+            let nil_tag = TagNil;
+            let cons_tag = Tag::Cons;
+            let err_tag = Tag::Err;
+            let invalid_form = EvalErr::InvalidForm;
+            match head [|sym| digests.ptr(sym).to_field()] {
+                "let", "letrec", "lambda", "cons", "strcons", "type-eq", "type-eqq" => {
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (fst_tag, fst, rest_tag, rest) = load(rest);
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (snd_tag, snd, rest_tag, _rest) = load(rest);
+                    let rest_not_nil = sub(rest_tag, nil_tag);
+                    if rest_not_nil {
+                        return (err_tag, invalid_form)
+                    }
+                    match head [|sym| digests.ptr(sym).to_field()] {
+                        "let" => {
+                            // first element: let symbol
+                            // second element: binding list
+                            // third element: body
+                            let (res_tag, res) = call(eval_let, fst_tag, fst, snd_tag, snd, env);
+                            return (res_tag, res)
+                        }
+                        "letrec" => {
+                            // analogous to `let`
+                            let (res_tag, res) = call(eval_letrec, fst_tag, fst, snd_tag, snd, env);
+                            return (res_tag, res)
+                        }
+                        "lambda" => {
+                            // first element: lambda symbol
+                            // second element: parameter list
+                            // third element: body
+                            // A function (more precisely, a closure) is an object with a
+                            // parameter list, a body and an environment
+                            let res_tag = Tag::Fun;
+                            let res = store(fst_tag, fst, snd_tag, snd, env);
+                            return (res_tag, res)
+                        }
+                        "cons", "strcons" => {
+                            let (res_tag, res) = call(eval_binop_misc, head, fst_tag, fst, snd_tag, snd, env);
+                            return (res_tag, res)
+                        }
+                        "type-eq" => {
+                            let (fst_tag, fst) = call(eval, fst_tag, fst, env);
+                            match fst_tag {
+                                Tag::Err => {
+                                    return (fst_tag, fst)
+                                }
+                            };
+                            let (snd_tag, snd) = call(eval, snd_tag, snd, env);
+                            match snd_tag {
+                                Tag::Err => {
+                                    return (snd_tag, snd)
+                                }
+                            };
+                            let type_not_eq = sub(fst_tag, snd_tag);
+                            if type_not_eq {
+                                let nil = digests.ptr("nil");
+                                return (nil_tag, nil)
+                            }
+                            let t_tag = TagT;
+                            let t = digests.ptr("t");
+                            return (t_tag, t)
+                        }
+                        "type-eqq" => {
+                            let (snd_tag, snd) = call(eval, snd_tag, snd, env);
+                            match snd_tag {
+                                Tag::Err => {
+                                    return (snd_tag, snd)
+                                }
+                            };
+                            let type_not_eqq = sub(fst_tag, snd_tag);
+                            if type_not_eqq {
+                                let nil = digests.ptr("nil");
+                                return (nil_tag, nil)
+                            }
+                            let t_tag = TagT;
+                            let t = digests.ptr("t");
+                            return (t_tag, t)
+                        }
+                    }
+                }
+                "list" => {
+                    let (expr_tag, expr) = call(eval_list, rest_tag, rest, env);
+                    return (expr_tag, expr)
+                }
+                "+", "-", "*", "/", "%", "=", "<", ">", "<=", ">=" => {
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (fst_tag, fst, rest_tag, rest) = load(rest);
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (snd_tag, snd, rest_tag, _rest) = load(rest);
+                    let rest_not_nil = sub(rest_tag, nil_tag);
+                    if rest_not_nil {
+                        return (err_tag, invalid_form)
+                    }
+                    let (res_tag, res) = call(eval_binop_num, head, fst_tag, fst, snd_tag, snd, env);
+                    return (res_tag, res)
+                }
+                "eval" => {
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (expr_tag, expr, rest_tag, rest) = load(rest);
+                    match rest_tag {
+                        TagNil => {
+                            // Eval must be called twice, first with the original env and then
+                            // with an empty env
+                            let (res_tag, res) = call(eval, expr_tag, expr, env);
+                            match res_tag {
+                                Tag::Err => {
+                                    return (res_tag, res)
+                                }
+                            };
+                            let env = 0;
+                            let (res_tag, res) = call(eval, res_tag, res, env);
+                            return (res_tag, res)
+                        }
+                        Tag::Cons => {
+                            let (env_expr_tag, env_expr, rest_tag, _rest) = load(rest);
+                            let rest_not_nil = sub(rest_tag, nil_tag);
+                            if rest_not_nil {
+                                return (err_tag, invalid_form)
+                            }
+                            let (res_tag, res) = call(eval, expr_tag, expr, env);
+                            match res_tag {
+                                Tag::Err => {
+                                    return (res_tag, res)
+                                }
+                            };
+                            let (env_tag, new_env) = call(eval, env_expr_tag, env_expr, env);
+                            match env_tag {
+                                Tag::Err => {
+                                    return (env_tag, new_env)
+                                }
+                                Tag::Env => {
+                                    let (res_tag, res) = call(eval, res_tag, res, new_env);
+                                    return (res_tag, res)
+                                }
+                            };
+                            let err = EvalErr::NotEnv;
+                            return (err_tag, err)
+                        }
+                    };
+                    let not_env = EvalErr::NotEnv;
+                    return (err_tag, not_env)
+                }
+                "quote" => {
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (expr_tag, expr, rest_tag, _rest) = load(rest);
+                    let rest_not_nil = sub(rest_tag, nil_tag);
+                    if rest_not_nil {
+                        return (err_tag, invalid_form)
+                    }
+                    return (expr_tag, expr)
+                }
+                "begin" => {
+                    let (expr_tag, expr) = call(eval_begin, rest_tag, rest, env);
+                    return (expr_tag, expr)
+                }
+                "current-env", "empty-env" => {
+                    let rest_not_nil = sub(rest_tag, nil_tag);
+                    if rest_not_nil {
+                        return (err_tag, invalid_form)
+                    }
+                    let env_tag = Tag::Env;
+                    match head [|sym| digests.ptr(sym).to_field()] {
+                        "current-env" => {
+                            return (env_tag, env)
+                        }
+                        "empty-env" => {
+                            let env = 0;
+                            return (env_tag, env)
+                        }
+                    }
+                }
+                "breakpoint" => {
+                    breakpoint;
+                    match rest_tag {
+                        TagNil => {
+                            let nil = digests.ptr("nil");
+                            return (nil_tag, nil)
+                        }
+                        Tag::Cons => {
+                            let (expr_tag, expr, rest_tag, _rest) = load(rest);
+                            let rest_not_nil = sub(rest_tag, nil_tag);
+                            if rest_not_nil {
+                                return (err_tag, invalid_form)
+                            }
+                            let (val_tag, val) = call(eval, expr_tag, expr, env);
+                            return (val_tag, val)
+                        }
+                    }
+                }
+                "if" => {
+                    // An if expression is a list of 3 or 4 elements
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (expr_tag, expr, rest_tag, rest) = load(rest);
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (t_branch_tag, t_branch, rest_tag, rest) = load(rest);
+                    match rest_tag {
+                        TagNil => {
+                            let (val_tag, val) = call(eval, expr_tag, expr, env);
+                            match val_tag {
+                                TagNil, Tag::Err => {
+                                    return (val_tag, val)
+                                }
+                            };
+                            let (res_tag, res) = call(eval, t_branch_tag, t_branch, env);
+                            return (res_tag, res)
+                        }
+                        Tag::Cons => {
+                            let (f_branch_tag, f_branch, rest_tag, _rest) = load(rest);
+                            let rest_not_nil = sub(rest_tag, nil_tag);
+                            if rest_not_nil {
+                                return (err_tag, invalid_form)
+                            }
+                            let (val_tag, val) = call(eval, expr_tag, expr, env);
+                            match val_tag {
+                                TagNil => {
+                                    let (res_tag, res) = call(eval, f_branch_tag, f_branch, env);
+                                    return (res_tag, res)
+                                }
+                                Tag::Err => {
+                                    return (val_tag, val)
+                                }
+                            };
+                            let (res_tag, res) = call(eval, t_branch_tag, t_branch, env);
+                            return (res_tag, res)
+                        }
+                    };
+                    return (err_tag, invalid_form)
+                }
+                "eq" => {
+                    let res: [2] = call(equal, rest_tag, rest, env);
+                    return res
+                }
+                "hide" => {
+                    let (res_tag, res) = call(eval_hide, rest_tag, rest, env);
+                    return (res_tag, res)
+                }
+                "car", "cdr" => {
+                    let (car_tag, car, cdr_tag, cdr) = call(car_cdr, rest_tag, rest, env);
+                    match head [|sym| digests.ptr(sym).to_field()] {
+                        "car" => {
+                            return (car_tag, car)
+                        }
+                        "cdr" => {
+                            return (cdr_tag, cdr)
+                        }
+                    }
+                }
+                "u64", "char", "atom", "emit", "bignum", "comm" => {
+                    let (res_tag, res) = call(eval_unop, head, rest_tag, rest, env);
+                    return (res_tag, res)
+                }
+                "commit", "open", "secret" => {
+                    let (res_tag, res) = call(eval_opening_unop, head, rest_tag, rest, env);
+                    return (res_tag, res)
+                }
+                // TODO: other built-ins
+            }
+        }
+    )
+}
+
 pub fn open_comm<F: AbstractField + Ord>() -> FuncE<F> {
     func!(
         fn open_comm(hash_ptr): [2] {
             let comm_hash: [8] = load(hash_ptr);
             let (_secret: [8], payload_tag, padding: [7], val_digest: [8]) = preimg(hash_24_8, comm_hash);
-            let payload_ptr = call(ingress, payload_tag, padding, val_digest);
+            let (payload_tag, payload_ptr) = call(ingress, payload_tag, padding, val_digest);
             return (payload_tag, payload_ptr)
         }
     )
 }
 
-pub fn car_cdr<F: AbstractField + Ord>() -> FuncE<F> {
+pub fn car_cdr<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
         partial fn car_cdr(rest_tag, rest, env): [4] {
-            let nil = 0;
-            let nil_tag = Tag::Nil;
+            let nil = digests.ptr("nil");
+            let nil_tag = TagNil;
             let err_tag = Tag::Err;
             let cons_tag = Tag::Cons;
             let invalid_form = EvalErr::InvalidForm;
@@ -934,7 +910,7 @@ pub fn car_cdr<F: AbstractField + Ord>() -> FuncE<F> {
                     let (car_tag, car, cdr_tag, cdr) = load(val);
                     return (car_tag, car, cdr_tag, cdr)
                 }
-                Tag::Nil => {
+                TagNil => {
                     return (nil_tag, nil, nil_tag, nil)
                 }
                 Tag::Str => {
@@ -955,12 +931,12 @@ pub fn car_cdr<F: AbstractField + Ord>() -> FuncE<F> {
     )
 }
 
-pub fn equal<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
+pub fn equal<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
         partial fn equal(rest_tag, rest, env): [2] {
             let err_tag = Tag::Err;
             let cons_tag = Tag::Cons;
-            let nil_tag = Tag::Nil;
+            let nil_tag = TagNil;
             let invalid_form = EvalErr::InvalidForm;
             let rest_not_cons = sub(rest_tag, cons_tag);
             if rest_not_cons {
@@ -990,9 +966,9 @@ pub fn equal<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> 
             };
             let is_equal_inner = call(equal_inner, val1_tag, val1, val2_tag, val2);
             if is_equal_inner {
-                let builtin_tag = Tag::Builtin;
-                let t = builtins.index("t");
-                return (builtin_tag, t)
+                let t_tag = TagT;
+                let t = digests.ptr("t");
+                return (t_tag, t)
             }
             return (nil_tag, is_equal_inner) // `is_equal_inner` is zero
         }
@@ -1098,7 +1074,7 @@ pub fn eval_list<F: AbstractField + Ord>() -> FuncE<F> {
     func!(
         partial fn eval_list(rest_tag, rest, env): [2] {
             match rest_tag {
-                Tag::Nil => {
+                TagNil => {
                     return (rest_tag, rest)
                 }
                 Tag::Cons => {
@@ -1131,7 +1107,7 @@ pub fn eval_begin<F: AbstractField + Ord>() -> FuncE<F> {
     func!(
         partial fn eval_begin(rest_tag, rest, env): [2] {
             match rest_tag {
-                Tag::Nil => {
+                TagNil => {
                     return (rest_tag, rest)
                 }
                 Tag::Cons => {
@@ -1142,13 +1118,13 @@ pub fn eval_begin<F: AbstractField + Ord>() -> FuncE<F> {
                             return (head_tag, head)
                         }
                     };
-                    match rest_tag {
-                        Tag::Nil => {
-                            return (head_tag, head)
-                        }
-                    };
-                    let (res_tag, res) = call(eval_begin, rest_tag, rest, env);
-                    return (res_tag, res)
+                    let nil_tag = TagNil;
+                    let rest_not_nil = sub(nil_tag, rest_tag);
+                    if rest_not_nil {
+                        let (res_tag, res) = call(eval_begin, rest_tag, rest, env);
+                        return (res_tag, res)
+                    }
+                    return (head_tag, head)
                 }
             };
             let err_tag = Tag::Err;
@@ -1158,17 +1134,16 @@ pub fn eval_begin<F: AbstractField + Ord>() -> FuncE<F> {
     )
 }
 
-pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
+pub fn eval_binop_num<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
         partial fn eval_binop_num(head, exp1_tag, exp1, exp2_tag, exp2, env): [2] {
             let err_tag = Tag::Err;
             let num_tag = Tag::Num;
             let u64_tag = Tag::U64;
-            let nil_tag = Tag::Nil;
+            let nil_tag = TagNil;
             let err_div_zero = EvalErr::DivByZero;
-            let builtin_tag = Tag::Builtin;
-            let t = builtins.index("t");
-            let nil = 0;
+            let t = digests.ptr("t");
+            let nil = digests.ptr("nil");
             let (val1_tag, val1) = call(eval, exp1_tag, exp1, env);
             match val1_tag {
                 Tag::Err => {
@@ -1181,10 +1156,11 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                     return (val2_tag, val2)
                 }
             };
+            let t_tag = TagT;
             let tags: [2] = (val1_tag, val2_tag);
             match tags {
                 [Tag::U64, Tag::U64] => {
-                    match head [|sym| builtins.index(sym).to_field()] {
+                    match head [|sym| digests.ptr(sym).to_field()] {
                         "+" => {
                             let res = call(u64_add, val1, val2);
                             return (u64_tag, res)
@@ -1203,7 +1179,7 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                                 return (err_tag, err_div_zero)
                             }
                             let (quot, rem) = call(u64_divrem, val1, val2);
-                            match head [|sym| builtins.index(sym).to_field()] {
+                            match head [|sym| digests.ptr(sym).to_field()] {
                                 "/" => {
                                     return (u64_tag, quot)
                                 }
@@ -1215,7 +1191,7 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                         "<" => {
                             let res = call(u64_lessthan, val1, val2);
                             if res {
-                                return (builtin_tag, t)
+                                return (t_tag, t)
                             }
                             return (nil_tag, nil)
                         }
@@ -1224,13 +1200,13 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                             if res {
                                 return (nil_tag, nil)
                             }
-                            return (builtin_tag, t)
+                            return (t_tag, t)
 
                         }
                         ">" => {
                             let res = call(u64_lessthan, val2, val1);
                             if res {
-                                return (builtin_tag, t)
+                                return (t_tag, t)
                             }
                             return (nil_tag, nil)
                         }
@@ -1239,19 +1215,19 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                             if res {
                                 return (nil_tag, nil)
                             }
-                            return (builtin_tag, t)
+                            return (t_tag, t)
                         }
                         "=" => {
                             let res = call(digest_equal, val1, val2);
                             if res {
-                                return (builtin_tag, t)
+                                return (t_tag, t)
                             }
                             return (nil_tag, nil)
                         }
                     }
                 }
                 [Tag::Num, Tag::Num] => {
-                    match head [|sym| builtins.index(sym).to_field()] {
+                    match head [|sym| digests.ptr(sym).to_field()] {
                         "+" => {
                             let res = add(val1, val2);
                             return (num_tag, res)
@@ -1276,7 +1252,7 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                             if diff {
                                 return (nil_tag, nil)
                             }
-                            return (builtin_tag, t)
+                            return (t_tag, t)
                         }
                         "%", "<", ">", "<=", ">=" => {
                             let err = EvalErr::NotU64;
@@ -1285,11 +1261,11 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                     }
                 }
                 [Tag::BigNum, Tag::BigNum] => {
-                    match head [|sym| builtins.index(sym).to_field()] {
+                    match head [|sym| digests.ptr(sym).to_field()] {
                         "<" => {
                             let res = call(big_num_lessthan, val1, val2);
                             if res {
-                                return (builtin_tag, t)
+                                return (t_tag, t)
                             }
                             return (nil_tag, nil)
                         }
@@ -1298,13 +1274,13 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                             if res {
                                 return (nil_tag, nil)
                             }
-                            return (builtin_tag, t)
+                            return (t_tag, t)
 
                         }
                         ">" => {
                             let res = call(big_num_lessthan, val2, val1);
                             if res {
-                                return (builtin_tag, t)
+                                return (t_tag, t)
                             }
                             return (nil_tag, nil)
                         }
@@ -1313,12 +1289,12 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
                             if res {
                                 return (nil_tag, nil)
                             }
-                            return (builtin_tag, t)
+                            return (t_tag, t)
                         }
                         "=" => {
                             let res = call(digest_equal, val2, val1);
                             if res {
-                                return (builtin_tag, t)
+                                return (t_tag, t)
                             }
                             return (nil_tag, nil)
                         }
@@ -1335,7 +1311,7 @@ pub fn eval_binop_num<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> 
     )
 }
 
-pub fn eval_binop_misc<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
+pub fn eval_binop_misc<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
         partial fn eval_binop_misc(head, exp1_tag, exp1, exp2_tag, exp2, env): [2] {
             let err_tag = Tag::Err;
@@ -1352,7 +1328,7 @@ pub fn eval_binop_misc<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) ->
                     return (val2_tag, val2)
                 }
             };
-            match head [|sym| builtins.index(sym).to_field()] {
+            match head [|sym| digests.ptr(sym).to_field()] {
                 "cons" => {
                     let cons = store(val1_tag, val1, val2_tag, val2);
                     return (cons_tag, cons)
@@ -1378,12 +1354,12 @@ pub fn eval_binop_misc<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) ->
     )
 }
 
-pub fn eval_unop<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
+pub fn eval_unop<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
         partial fn eval_unop(head, rest_tag, rest, env): [2] {
             let err_tag = Tag::Err;
             let cons_tag = Tag::Cons;
-            let nil_tag = Tag::Nil;
+            let nil_tag = TagNil;
             let invalid_form = EvalErr::InvalidForm;
             let rest_not_cons = sub(rest_tag, cons_tag);
             if rest_not_cons {
@@ -1401,15 +1377,15 @@ pub fn eval_unop<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE
                 }
             };
 
-            match head [|sym| builtins.index(sym).to_field()] {
+            match head [|sym| digests.ptr(sym).to_field()] {
                 "atom" => {
                     let val_not_cons = sub(val_tag, cons_tag);
                     if val_not_cons {
-                        let builtin_tag = Tag::Builtin;
-                        let t = builtins.index("t");
-                        return (builtin_tag, t)
+                        let t_tag = TagT;
+                        let t = digests.ptr("t");
+                        return (t_tag, t)
                     }
-                    let nil = 0;
+                    let nil = digests.ptr("nil");
                     return (nil_tag, nil)
                 }
                 "emit" => {
@@ -1478,12 +1454,12 @@ pub fn eval_unop<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE
     )
 }
 
-pub fn eval_opening_unop<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
+pub fn eval_opening_unop<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     func!(
         partial fn eval_opening_unop(head, rest_tag, rest, env): [2] {
             let err_tag = Tag::Err;
             let cons_tag = Tag::Cons;
-            let nil_tag = Tag::Nil;
+            let nil_tag = TagNil;
             let invalid_form = EvalErr::InvalidForm;
             let rest_not_cons = sub(rest_tag, cons_tag);
             if rest_not_cons {
@@ -1501,9 +1477,9 @@ pub fn eval_opening_unop<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) 
                 }
             };
 
-            match head [|sym| builtins.index(sym).to_field()] {
+            match head [|sym| digests.ptr(sym).to_field()] {
                 "commit" => {
-                    let val_digest: [8] = call(egress, val_tag, val);
+                    let (val_tag, val_digest: [8]) = call(egress, val_tag, val);
                     let padding = [0; 7];
                     let zero = 0;
                     let comm_hash: [8] = call(hash_24_8, zero, padding, val_tag, padding, val_digest);
@@ -1511,32 +1487,27 @@ pub fn eval_opening_unop<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) 
                     let comm_ptr = store(comm_hash);
                     return (comm_tag, comm_ptr)
                 }
-                "open" => {
-                    match val_tag {
-                        Tag::Comm, Tag::BigNum => {
-                            let comm_hash: [8] = load(val);
-                            let (_secret: [8], tag, padding: [7], val_digest: [8]) = preimg(hash_24_8, comm_hash);
-                            let ptr = call(ingress, tag, padding, val_digest);
+            };
+            // default case must be `open` or `secret`
+            match val_tag {
+                Tag::Comm, Tag::BigNum => {
+                    let comm_hash: [8] = load(val);
+                    let (secret: [8], tag, padding: [7], val_digest: [8]) = preimg(hash_24_8, comm_hash);
+                    match head [|sym| digests.ptr(sym).to_field()] {
+                        "open" => {
+                            let (tag, ptr) = call(ingress, tag, padding, val_digest);
                             return (tag, ptr)
                         }
-                    };
-                    let cant_open = EvalErr::CantOpen;
-                    return (err_tag, cant_open)
-                }
-                "secret" => {
-                    match val_tag {
-                        Tag::Comm, Tag::BigNum => {
-                            let comm_hash: [8] = load(val);
-                            let (secret: [8], _payload: [16]) = preimg(hash_24_8, comm_hash);
+                        "secret" => {
                             let ptr = store(secret);
                             let big_num_tag = Tag::BigNum;
                             return (big_num_tag, ptr)
                         }
-                    };
-                    let cant_open = EvalErr::CantOpen;
-                    return (err_tag, cant_open)
+                    }
                 }
-             }
+            };
+            let cant_open = EvalErr::CantOpen;
+            return (err_tag, cant_open)
         }
     )
 }
@@ -1546,7 +1517,7 @@ pub fn eval_hide<F: AbstractField + Ord>() -> FuncE<F> {
         partial fn eval_hide(rest_tag, rest, env): [2] {
             let err_tag = Tag::Err;
             let cons_tag = Tag::Cons;
-            let nil_tag = Tag::Nil;
+            let nil_tag = TagNil;
             let invalid_form = EvalErr::InvalidForm;
             let rest_not_cons = sub(rest_tag, cons_tag);
             if rest_not_cons {
@@ -1577,7 +1548,7 @@ pub fn eval_hide<F: AbstractField + Ord>() -> FuncE<F> {
             match val1_tag {
                 Tag::BigNum => {
                     let secret: [8] = load(val1);
-                    let val2_digest: [8] = call(egress, val2_tag, val2);
+                    let (val2_tag, val2_digest: [8]) = call(egress, val2_tag, val2);
                     let padding = [0; 7];
                     let comm_hash: [8] = call(hash_24_8, secret, val2_tag, padding, val2_digest);
                     let comm_ptr = store(comm_hash);
@@ -1597,14 +1568,13 @@ pub fn eval_let<F: AbstractField + Ord>() -> FuncE<F> {
             let err_tag = Tag::Err;
             let invalid_form = EvalErr::InvalidForm;
             match binds_tag {
-                Tag::Nil => {
+                TagNil => {
                     let (res_tag, res) = call(eval, body_tag, body, env);
                     return (res_tag, res)
                 }
                 Tag::Cons => {
                     let cons_tag = Tag::Cons;
-                    let nil_tag = Tag::Nil;
-                    let sym_tag = Tag::Sym;
+                    let nil_tag = TagNil;
                     // `binds` is a list of bindings
                     let (bind_tag, bind, rest_binds_tag, rest_binds) = load(binds);
                     let bind_not_cons = sub(bind_tag, cons_tag);
@@ -1617,31 +1587,33 @@ pub fn eval_let<F: AbstractField + Ord>() -> FuncE<F> {
                     if rest_not_cons {
                         return (err_tag, invalid_form)
                     }
-                    let param_not_sym = sub(param_tag, sym_tag);
-                    if param_not_sym {
-                        return (err_tag, invalid_form)
-                    }
-                    let (expr_tag, expr, rest_tag, _rest) = load(rest);
-                    let rest_not_nil = sub(rest_tag, nil_tag);
-                    if rest_not_nil {
-                        return (err_tag, invalid_form)
-                    }
+                    match param_tag {
+                        Tag::Sym, Tag::Builtin => {
+                            let (expr_tag, expr, rest_tag, _rest) = load(rest);
+                            let rest_not_nil = sub(rest_tag, nil_tag);
+                            if rest_not_nil {
+                                return (err_tag, invalid_form)
+                            }
 
-                    let (val_tag, val) = call(eval, expr_tag, expr, env);
-                    match val_tag {
-                        Tag::Err => {
-                            return (val_tag, val)
-                        }
-                    };
-                    let ext_env = store(param, val_tag, val, env);
-                    match rest_binds_tag {
-                        Tag::Nil => {
+                            let (val_tag, val) = call(eval, expr_tag, expr, env);
+                            match val_tag {
+                                Tag::Err => {
+                                    return (val_tag, val)
+                                }
+                            };
+                            let ext_env = store(param, val_tag, val, env);
+                            let rest_binds_not_nil = sub(nil_tag, rest_binds_tag);
+                            if rest_binds_not_nil {
+                                let (res_tag, res) = call(eval_let, rest_binds_tag, rest_binds, body_tag, body, ext_env);
+                                return (res_tag, res)
+                            }
                             let (res_tag, res) = call(eval, body_tag, body, ext_env);
                             return (res_tag, res)
                         }
                     };
-                    let (res_tag, res) = call(eval_let, rest_binds_tag, rest_binds, body_tag, body, ext_env);
-                    return (res_tag, res)
+                    let err = EvalErr::IllegalBindingVar;
+                    return (err_tag, err)
+
                 }
             };
             return (err_tag, invalid_form)
@@ -1655,14 +1627,12 @@ pub fn eval_letrec<F: AbstractField + Ord>() -> FuncE<F> {
             let err_tag = Tag::Err;
             let invalid_form = EvalErr::InvalidForm;
             match binds_tag {
-                Tag::Nil => {
+                TagNil => {
                     let (res_tag, res) = call(eval, body_tag, body, env);
                     return (res_tag, res)
                 }
                 Tag::Cons => {
                     let cons_tag = Tag::Cons;
-                    let nil_tag = Tag::Nil;
-                    let sym_tag = Tag::Sym;
                     // `binds` is a list of bindings
                     let (bind_tag, bind, rest_binds_tag, rest_binds) = load(binds);
                     let bind_not_cons = sub(bind_tag, cons_tag);
@@ -1675,36 +1645,38 @@ pub fn eval_letrec<F: AbstractField + Ord>() -> FuncE<F> {
                     if rest_not_cons {
                         return (err_tag, invalid_form)
                     }
-                    let param_not_sym = sub(param_tag, sym_tag);
-                    if param_not_sym {
-                        return (err_tag, invalid_form)
-                    }
-                    let (expr_tag, expr, rest_tag, _rest) = load(rest);
-                    let rest_not_nil = sub(rest_tag, nil_tag);
-                    if rest_not_nil {
-                        return (err_tag, invalid_form)
-                    }
+                    match param_tag {
+                        Tag::Sym, Tag::Builtin => {
+                            let (expr_tag, expr, rest_tag, _rest) = load(rest);
+                            let nil_tag = TagNil;
+                            let rest_not_nil = sub(rest_tag, nil_tag);
+                            if rest_not_nil {
+                                return (err_tag, invalid_form)
+                            }
 
-                    let thunk_tag = Tag::Thunk;
-                    let thunk = store(expr_tag, expr, env);
-                    let ext_env = store(param, thunk_tag, thunk, env);
-                    // this will preemptively evaluate the thunk, so that we do not skip evaluation in case
-                    // the variable is not used inside the letrec body, and furthermore it follows a strict
-                    // evaluation order
-                    let (val_tag, val) = call(eval, expr_tag, expr, ext_env);
-                    match val_tag {
-                        Tag::Err => {
-                            return (val_tag, val)
-                        }
-                    };
-                    match rest_binds_tag {
-                        Tag::Nil => {
+                            let thunk_tag = Tag::Thunk;
+                            let thunk = store(expr_tag, expr, env);
+                            let ext_env = store(param, thunk_tag, thunk, env);
+                            // this will preemptively evaluate the thunk, so that we do not skip evaluation in case
+                            // the variable is not used inside the letrec body, and furthermore it follows a strict
+                            // evaluation order
+                            let (val_tag, val) = call(eval, expr_tag, expr, ext_env);
+                            match val_tag {
+                                Tag::Err => {
+                                    return (val_tag, val)
+                                }
+                            };
+                            let rest_binds_not_nil = sub(nil_tag, rest_binds_tag);
+                            if rest_binds_not_nil {
+                                let (res_tag, res) = call(eval_letrec, rest_binds_tag, rest_binds, body_tag, body, ext_env);
+                                return (res_tag, res)
+                            }
                             let (res_tag, res) = call(eval, body_tag, body, ext_env);
                             return (res_tag, res)
                         }
                     };
-                    let (res_tag, res) = call(eval_letrec, rest_binds_tag, rest_binds, body_tag, body, ext_env);
-                    return (res_tag, res)
+                    let err = EvalErr::IllegalBindingVar;
+                    return (err_tag, err)
                 }
             };
             return (err_tag, invalid_form)
@@ -1732,7 +1704,7 @@ pub fn apply<F: AbstractField + Ord>() -> FuncE<F> {
             let (params_tag, params, body_tag, body, func_env) = load(head);
 
             match params_tag {
-                Tag::Nil => {
+                TagNil => {
                     let (res_tag, res) = call(eval, body_tag, body, func_env);
                     match res_tag {
                         Tag::Err => {
@@ -1740,7 +1712,7 @@ pub fn apply<F: AbstractField + Ord>() -> FuncE<F> {
                         }
                     };
                     match args_tag {
-                        Tag::Nil => {
+                        TagNil => {
                             return (res_tag, res)
                         }
                         Tag::Cons => {
@@ -1754,32 +1726,32 @@ pub fn apply<F: AbstractField + Ord>() -> FuncE<F> {
                 }
                 Tag::Cons => {
                     match args_tag {
-                        Tag::Nil => {
+                        TagNil => {
                             // Undersaturated application
                             return (head_tag, head)
                         }
                         Tag::Cons => {
                             let (param_tag, param, rest_params_tag, rest_params) = load(params);
                             let (arg_tag, arg, rest_args_tag, rest_args) = load(args);
-                            let sym_tag = Tag::Sym;
-                            let param_not_sym = sub(param_tag, sym_tag);
-                            if param_not_sym {
-                                let err = EvalErr::ParamNotSymbol;
-                                return (err_tag, err)
-                            }
-                            // evaluate the argument
-                            let (arg_tag, arg) = call(eval, arg_tag, arg, args_env);
-                            match arg_tag {
-                                Tag::Err => {
-                                    return (arg_tag, arg)
+                            match param_tag {
+                                Tag::Sym, Tag::Builtin => {
+                                    // evaluate the argument
+                                    let (arg_tag, arg) = call(eval, arg_tag, arg, args_env);
+                                    match arg_tag {
+                                        Tag::Err => {
+                                            return (arg_tag, arg)
+                                        }
+                                    };
+                                    // and store it in the environment
+                                    let ext_env = store(param, arg_tag, arg, func_env);
+                                    let ext_fun = store(rest_params_tag, rest_params, body_tag, body, ext_env);
+                                    let (res_tag, res) = call(apply, fun_tag, ext_fun, rest_args_tag, rest_args, args_env);
+
+                                    return (res_tag, res)
                                 }
                             };
-                            // and store it in the environment
-                            let ext_env = store(param, arg_tag, arg, func_env);
-                            let ext_fun = store(rest_params_tag, rest_params, body_tag, body, ext_env);
-                            let (res_tag, res) = call(apply, fun_tag, ext_fun, rest_args_tag, rest_args, args_env);
-
-                            return (res_tag, res)
+                            let err = EvalErr::IllegalBindingVar;
+                            return (err_tag, err)
                         }
                     };
                     let err = EvalErr::ArgsNotList;
@@ -1835,7 +1807,9 @@ mod test {
         let (toplevel, _) = &build_lurk_toplevel();
 
         let lurk_main = FuncChip::from_name("lurk_main", toplevel);
+        let preallocate_symbols = FuncChip::from_name("preallocate_symbols", toplevel);
         let eval = FuncChip::from_name("eval", toplevel);
+        let eval_builtin_expr = FuncChip::from_name("eval_builtin_expr", toplevel);
         let eval_opening_unop = FuncChip::from_name("eval_opening_unop", toplevel);
         let eval_hide = FuncChip::from_name("eval_hide", toplevel);
         let eval_unop = FuncChip::from_name("eval_unop", toplevel);
@@ -1852,9 +1826,7 @@ mod test {
         let apply = FuncChip::from_name("apply", toplevel);
         let env_lookup = FuncChip::from_name("env_lookup", toplevel);
         let ingress = FuncChip::from_name("ingress", toplevel);
-        let ingress_builtin = FuncChip::from_name("ingress_builtin", toplevel);
         let egress = FuncChip::from_name("egress", toplevel);
-        let egress_builtin = FuncChip::from_name("egress_builtin", toplevel);
         let hash_24_8 = FuncChip::from_name("hash_24_8", toplevel);
         let hash_32_8 = FuncChip::from_name("hash_32_8", toplevel);
         let hash_48_8 = FuncChip::from_name("hash_48_8", toplevel);
@@ -1870,27 +1842,27 @@ mod test {
         let expect_eq = |computed: usize, expected: Expect| {
             expected.assert_eq(&computed.to_string());
         };
-        expect_eq(lurk_main.width(), expect!["91"]);
-        expect_eq(eval.width(), expect!["155"]);
-        expect_eq(eval_opening_unop.width(), expect!["96"]);
-        expect_eq(eval_hide.width(), expect!["114"]);
+        expect_eq(lurk_main.width(), expect!["97"]);
+        expect_eq(preallocate_symbols.width(), expect!["164"]);
+        expect_eq(eval.width(), expect!["75"]);
+        expect_eq(eval_builtin_expr.width(), expect!["141"]);
+        expect_eq(eval_opening_unop.width(), expect!["97"]);
+        expect_eq(eval_hide.width(), expect!["115"]);
         expect_eq(eval_unop.width(), expect!["78"]);
         expect_eq(eval_binop_num.width(), expect!["107"]);
         expect_eq(eval_binop_misc.width(), expect!["70"]);
         expect_eq(eval_begin.width(), expect!["68"]);
         expect_eq(eval_list.width(), expect!["72"]);
-        expect_eq(eval_let.width(), expect!["92"]);
-        expect_eq(eval_letrec.width(), expect!["96"]);
-        expect_eq(open_comm.width(), expect!["49"]);
+        expect_eq(eval_let.width(), expect!["93"]);
+        expect_eq(eval_letrec.width(), expect!["97"]);
+        expect_eq(open_comm.width(), expect!["50"]);
         expect_eq(equal.width(), expect!["82"]);
         expect_eq(equal_inner.width(), expect!["57"]);
         expect_eq(car_cdr.width(), expect!["61"]);
-        expect_eq(apply.width(), expect!["99"]);
+        expect_eq(apply.width(), expect!["100"]);
         expect_eq(env_lookup.width(), expect!["49"]);
-        expect_eq(ingress.width(), expect!["100"]);
-        expect_eq(ingress_builtin.width(), expect!["51"]);
-        expect_eq(egress.width(), expect!["77"]);
-        expect_eq(egress_builtin.width(), expect!["51"]);
+        expect_eq(ingress.width(), expect!["105"]);
+        expect_eq(egress.width(), expect!["81"]);
         expect_eq(hash_24_8.width(), expect!["493"]);
         expect_eq(hash_32_8.width(), expect!["655"]);
         expect_eq(hash_48_8.width(), expect!["975"]);

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -102,9 +102,9 @@ pub fn build_lurk_toplevel() -> (Toplevel<BabyBear, LurkChip>, ZStore<BabyBear, 
         env_lookup(),
         ingress(&digests),
         egress(&digests),
-        hash_24_8(),
-        hash_32_8(),
-        hash_40_8(),
+        hash3(),
+        hash4(),
+        hash5(),
         u64_add(),
         u64_sub(),
         u64_mul(),
@@ -275,7 +275,7 @@ pub fn ingress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                         return (tag, zero)
                     }
                     let (fst_tag_full: [8], fst_digest: [8],
-                         snd_tag_full: [8], snd_digest: [8]) = preimg(hash_32_8, digest);
+                         snd_tag_full: [8], snd_digest: [8]) = preimg(hash4, digest);
                     let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
                     let (snd_tag, snd_ptr) = call(ingress, snd_tag_full, snd_digest);
                     let ptr = store(fst_tag, fst_ptr, snd_tag, snd_ptr);
@@ -283,14 +283,14 @@ pub fn ingress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                 }
                 Tag::Cons => {
                     let (fst_tag_full: [8], fst_digest: [8],
-                         snd_tag_full: [8], snd_digest: [8]) = preimg(hash_32_8, digest);
+                         snd_tag_full: [8], snd_digest: [8]) = preimg(hash4, digest);
                     let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
                     let (snd_tag, snd_ptr) = call(ingress, snd_tag_full, snd_digest);
                     let ptr = store(fst_tag, fst_ptr, snd_tag, snd_ptr);
                     return (tag, ptr)
                 }
                 Tag::Thunk => {
-                    let (fst_tag_full: [8], fst_digest: [8], snd_digest: [8]) = preimg(hash_24_8, digest);
+                    let (fst_tag_full: [8], fst_digest: [8], snd_digest: [8]) = preimg(hash3, digest);
                     let env_tag = Tag::Env;
                     let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
                     let (_snd_tag, snd_ptr) = call(ingress, env_tag, zeros, snd_digest);
@@ -300,7 +300,7 @@ pub fn ingress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                 Tag::Fun => {
                     let (args_tag_full: [8], args_digest: [8],
                          body_tag_full: [8], body_digest: [8],
-                                             env_digest: [8]) = preimg(hash_40_8, digest);
+                                             env_digest: [8]) = preimg(hash5, digest);
                     let env_tag = Tag::Env;
                     let (args_tag, args_ptr) = call(ingress, args_tag_full, args_digest);
                     let (body_tag, body_ptr) = call(ingress, body_tag_full, body_digest);
@@ -315,7 +315,7 @@ pub fn ingress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                     }
                     let (var_tag_full: [8], var_digest: [8],
                          val_tag_full: [8], val_digest: [8],
-                                            env_digest: [8]) = preimg(hash_40_8, digest);
+                                            env_digest: [8]) = preimg(hash5, digest);
                     let (var_tag, var_ptr) = call(ingress, var_tag_full, var_digest);
                     let (val_tag, val_ptr) = call(ingress, val_tag_full, val_digest);
                     let (_tag, env_ptr) = call(ingress, tag, zeros, env_digest); // `tag` is `Tag::Env`
@@ -367,7 +367,7 @@ pub fn egress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
                     let snd_tag_full: [8] = (snd_tag, padding);
-                    let digest: [8] = call(hash_32_8, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
+                    let digest: [8] = call(hash4, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
                     return (tag, digest)
                 }
                 Tag::Cons => {
@@ -378,7 +378,7 @@ pub fn egress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
                     let snd_tag_full: [8] = (snd_tag, padding);
-                    let digest: [8] = call(hash_32_8, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
+                    let digest: [8] = call(hash4, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
                     return (tag, digest)
                 }
                 Tag::Thunk => {
@@ -389,7 +389,7 @@ pub fn egress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
 
                     let padding = [0; 7];
                     let fst_tag_full: [8] = (fst_tag, padding);
-                    let digest: [8] = call(hash_24_8, fst_tag_full, fst_digest, snd_digest);
+                    let digest: [8] = call(hash3, fst_tag_full, fst_digest, snd_digest);
                     return (tag, digest)
                 }
                 Tag::Fun => {
@@ -402,7 +402,7 @@ pub fn egress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                     let padding = [0; 7];
                     let args_tag_full: [8] = (args_tag, padding);
                     let body_tag_full: [8] = (body_tag, padding);
-                    let digest: [8] = call(hash_40_8, args_tag_full, args_digest, body_tag_full, body_digest, env_digest);
+                    let digest: [8] = call(hash5, args_tag_full, args_digest, body_tag_full, body_digest, env_digest);
                     return (tag, digest)
                 }
                 Tag::Env => {
@@ -418,7 +418,7 @@ pub fn egress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
                     let padding = [0; 7];
                     let var_tag_full: [8] = (var_tag, padding);
                     let val_tag_full: [8] = (val_tag, padding);
-                    let digest: [8] = call(hash_40_8, var_tag_full, var_digest, val_tag_full, val_digest, env_digest);
+                    let digest: [8] = call(hash5, var_tag_full, var_digest, val_tag_full, val_digest, env_digest);
                     return (tag, digest)
                 }
             }
@@ -426,28 +426,28 @@ pub fn egress<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F> {
     )
 }
 
-pub fn hash_24_8<F>() -> FuncE<F> {
+pub fn hash3<F>() -> FuncE<F> {
     func!(
-        invertible fn hash_24_8(preimg: [24]): [8] {
-            let img: [8] = extern_call(hash_24_8, preimg);
+        invertible fn hash3(preimg: [24]): [8] {
+            let img: [8] = extern_call(hasher3, preimg);
             return img
         }
     )
 }
 
-pub fn hash_32_8<F>() -> FuncE<F> {
+pub fn hash4<F>() -> FuncE<F> {
     func!(
-        invertible fn hash_32_8(preimg: [32]): [8] {
-            let img: [8] = extern_call(hash_32_8, preimg);
+        invertible fn hash4(preimg: [32]): [8] {
+            let img: [8] = extern_call(hasher4, preimg);
             return img
         }
     )
 }
 
-pub fn hash_40_8<F>() -> FuncE<F> {
+pub fn hash5<F>() -> FuncE<F> {
     func!(
-        invertible fn hash_40_8(preimg: [40]): [8] {
-            let img: [8] = extern_call(hash_40_8, preimg);
+        invertible fn hash5(preimg: [40]): [8] {
+            let img: [8] = extern_call(hasher5, preimg);
             return img
         }
     )
@@ -911,7 +911,7 @@ pub fn open_comm<F: AbstractField>() -> FuncE<F> {
     func!(
         fn open_comm(hash_ptr): [2] {
             let comm_hash: [8] = load(hash_ptr);
-            let (_secret: [8], payload_tag, padding: [7], val_digest: [8]) = preimg(hash_24_8, comm_hash);
+            let (_secret: [8], payload_tag, padding: [7], val_digest: [8]) = preimg(hash3, comm_hash);
             let (payload_tag, payload_ptr) = call(ingress, payload_tag, padding, val_digest);
             return (payload_tag, payload_ptr)
         }
@@ -1516,7 +1516,7 @@ pub fn eval_opening_unop<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F>
                     let (val_tag, val_digest: [8]) = call(egress, val_tag, val);
                     let padding = [0; 7];
                     let zero = 0;
-                    let comm_hash: [8] = call(hash_24_8, zero, padding, val_tag, padding, val_digest);
+                    let comm_hash: [8] = call(hash3, zero, padding, val_tag, padding, val_digest);
                     let comm_tag = Tag::Comm;
                     let comm_ptr = store(comm_hash);
                     return (comm_tag, comm_ptr)
@@ -1526,7 +1526,7 @@ pub fn eval_opening_unop<F: AbstractField>(digests: &Digests<'_, F>) -> FuncE<F>
             match val_tag {
                 Tag::Comm, Tag::BigNum => {
                     let comm_hash: [8] = load(val);
-                    let (secret: [8], tag, padding: [7], val_digest: [8]) = preimg(hash_24_8, comm_hash);
+                    let (secret: [8], tag, padding: [7], val_digest: [8]) = preimg(hash3, comm_hash);
                     match head [|sym| digests.ptr(sym).to_field()] {
                         "open" => {
                             let (tag, ptr) = call(ingress, tag, padding, val_digest);
@@ -1584,7 +1584,7 @@ pub fn eval_hide<F: AbstractField>() -> FuncE<F> {
                     let secret: [8] = load(val1);
                     let (val2_tag, val2_digest: [8]) = call(egress, val2_tag, val2);
                     let padding = [0; 7];
-                    let comm_hash: [8] = call(hash_24_8, secret, val2_tag, padding, val2_digest);
+                    let comm_hash: [8] = call(hash3, secret, val2_tag, padding, val2_digest);
                     let comm_ptr = store(comm_hash);
                     let comm_tag = Tag::Comm;
                     return (comm_tag, comm_ptr)
@@ -1863,9 +1863,9 @@ mod test {
         let env_lookup = FuncChip::from_name("env_lookup", toplevel);
         let ingress = FuncChip::from_name("ingress", toplevel);
         let egress = FuncChip::from_name("egress", toplevel);
-        let hash_24_8 = FuncChip::from_name("hash_24_8", toplevel);
-        let hash_32_8 = FuncChip::from_name("hash_32_8", toplevel);
-        let hash_40_8 = FuncChip::from_name("hash_40_8", toplevel);
+        let hash3 = FuncChip::from_name("hash3", toplevel);
+        let hash4 = FuncChip::from_name("hash4", toplevel);
+        let hash5 = FuncChip::from_name("hash5", toplevel);
         let u64_add = FuncChip::from_name("u64_add", toplevel);
         let u64_sub = FuncChip::from_name("u64_sub", toplevel);
         let u64_mul = FuncChip::from_name("u64_mul", toplevel);
@@ -1900,9 +1900,9 @@ mod test {
         expect_eq(env_lookup.width(), expect!["52"]);
         expect_eq(ingress.width(), expect!["105"]);
         expect_eq(egress.width(), expect!["82"]);
-        expect_eq(hash_24_8.width(), expect!["493"]);
-        expect_eq(hash_32_8.width(), expect!["655"]);
-        expect_eq(hash_40_8.width(), expect!["815"]);
+        expect_eq(hash3.width(), expect!["493"]);
+        expect_eq(hash4.width(), expect!["655"]);
+        expect_eq(hash5.width(), expect!["815"]);
         expect_eq(u64_add.width(), expect!["53"]);
         expect_eq(u64_sub.width(), expect!["53"]);
         expect_eq(u64_mul.width(), expect!["85"]);
@@ -1919,7 +1919,7 @@ mod test {
 
         let ingress = toplevel.get_by_name("ingress");
         let egress = toplevel.get_by_name("egress");
-        let hash_32_8_chip = FuncChip::from_name("hash_32_8", toplevel);
+        let hash4_chip = FuncChip::from_name("hash4", toplevel);
 
         let state = State::init_lurk_state().rccell();
 
@@ -1931,7 +1931,7 @@ mod test {
             let digest: List<_> = digest.into();
 
             let mut queries = QueryRecord::new(toplevel);
-            queries.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+            queries.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
 
             let mut ingress_args = [F::zero(); 16];
             ingress_args[0] = tag;
@@ -1952,8 +1952,8 @@ mod test {
                 "ingress -> egress doesn't roundtrip"
             );
 
-            let hash_32_8_trace = hash_32_8_chip.generate_trace(&Shard::new(&queries));
-            debug_constraints_collecting_queries(&hash_32_8_chip, &[], None, &hash_32_8_trace);
+            let hash4_trace = hash4_chip.generate_trace(&Shard::new(&queries));
+            debug_constraints_collecting_queries(&hash4_chip, &[], None, &hash4_trace);
         };
 
         assert_ingress_egress_correctness("~()");

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -546,7 +546,7 @@ pub fn eval<F: AbstractField>() -> FuncE<F> {
             match expr_tag {
                 Tag::Builtin, Tag::Sym => {
                     let expr_digest: [8] = load(expr);
-                    let (res_tag, res) = call(env_lookup, expr_digest, env);
+                    let (res_tag, res) = call(env_lookup, expr_tag, expr_digest, env);
                     match res_tag {
                         Tag::Thunk => {
                             // In the case the result is a thunk we extend
@@ -1789,19 +1789,20 @@ pub fn apply<F: AbstractField>() -> FuncE<F> {
 
 pub fn env_lookup<F: AbstractField>() -> FuncE<F> {
     func!(
-        fn env_lookup(x_digest: [8], env): [2] {
+        fn env_lookup(x_tag_digest: [9], env): [2] {
             if !env {
                 let err_tag = Tag::Err;
                 let err = EvalErr::UnboundVar;
                 return (err_tag, err)
             }
-            let (_y_tag, y, val_tag, val, tail_env) = load(env);
+            let (y_tag, y, val_tag, val, tail_env) = load(env);
             let y_digest: [8] = load(y);
-            let not_eq = sub(x_digest, y_digest);
+            let y_tag_digest: [9] = (y_tag, y_digest);
+            let not_eq = sub(x_tag_digest, y_tag_digest);
             if !not_eq {
                 return (val_tag, val)
             }
-            let (res_tag, res) = call(env_lookup, x_digest, tail_env);
+            let (res_tag, res) = call(env_lookup, x_tag_digest, tail_env);
             return (res_tag, res)
         }
     )
@@ -1885,7 +1886,7 @@ mod test {
         expect_eq(equal_inner.width(), expect!["57"]);
         expect_eq(car_cdr.width(), expect!["61"]);
         expect_eq(apply.width(), expect!["100"]);
-        expect_eq(env_lookup.width(), expect!["50"]);
+        expect_eq(env_lookup.width(), expect!["52"]);
         expect_eq(ingress.width(), expect!["105"]);
         expect_eq(egress.width(), expect!["82"]);
         expect_eq(hash_24_8.width(), expect!["493"]);

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -174,6 +174,16 @@ pub fn lurk_main<F: AbstractField>() -> FuncE<F> {
     )
 }
 
+/// ```ignore
+/// fn preallocate_symbols(): [0] {
+///     let arr: [8] = Array(<symbol 0 digest>);
+///     let _ptr = store(arr);
+///     let arr: [8] = Array(<symbol 1 digest>);
+///     let _ptr = store(arr);
+///     ...
+///     return
+/// }
+/// ```
 pub fn preallocate_symbols<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> FuncE<F> {
     let mut ops = Vec::with_capacity(2 * digests.0.len());
     let arr_var = Var {
@@ -186,7 +196,7 @@ pub fn preallocate_symbols<F: AbstractField + Ord>(digests: &Digests<'_, F>) -> 
     };
     for digest in digests.0.values() {
         ops.push(OpE::Array(arr_var, digest.clone()));
-        ops.push(OpE::Store(ptr_var, [arr_var].into())); // TODO: replace by `Preallocate(digest.clone())`
+        ops.push(OpE::Store(ptr_var, [arr_var].into()));
     }
     let ops = ops.into();
     let ctrl = CtrlE::Return([].into()); // TODO: replace by `Exit`

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -345,6 +345,10 @@ test!(
 );
 test!(test_type_eq1, "(type-eq 1 (+ 1 2))", |z| *z.t());
 test!(test_type_eq2, "(type-eq (+ 1 1) 'a')", |z| *z.nil());
+test!(test_type_eq3, "(type-eq nil t)", |z| *z.t());
+test!(test_type_eq4, "(type-eq 'a t)", |z| *z.t());
+test!(test_type_eq5, "(type-eq 'cons t)", |z| *z.nil());
+test!(test_type_eq6, "(type-eq 'cons 'let)", |z| *z.t());
 test!(test_type_eqq1, "(type-eqq (nil) (cons 1 2))", |z| *z.t());
 test!(test_type_eqq2, "(type-eqq 2 'a')", |z| *z.nil());
 test!(test_breakpoint, "(breakpoint)", |z| *z.nil());

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -497,6 +497,23 @@ test!(test_shadow4, "(let ((cons 1)) (cons cons cons))", |z| {
 
 // errors
 test!(test_unbound_var, "a", |_| ZPtr::err(EvalErr::UnboundVar));
+test_raw!(
+    test_unbound_var2,
+    |z| {
+        // binding the built-in `cons` but evaluating a `Tag::Sym`-tagged `cons`
+        // should resuld in an unbound var error
+        let let_ = z.intern_symbol(&builtin_sym("let"));
+        let cons = z.intern_symbol(&builtin_sym("cons"));
+        let one = uint(1);
+        assert_eq!(cons.tag, Tag::Builtin);
+        let mut cons_sym = cons.clone();
+        cons_sym.tag = Tag::Sym;
+        let binding = z.intern_list([cons, one]);
+        let bindings = z.intern_list([binding]);
+        z.intern_list([let_, bindings, cons_sym])
+    },
+    |_| ZPtr::err(EvalErr::UnboundVar)
+);
 test!(test_div_by_zero_fel, "(/ 1n 0n)", |_| ZPtr::err(
     EvalErr::DivByZero
 ));

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -52,9 +52,9 @@ fn run_test(
     config: BabyBearPoseidon2,
 ) {
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_24_8", toplevel, &zstore.hashes24);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
-    record.inject_inv_queries("hash_40_8", toplevel, &zstore.hashes40);
+    record.inject_inv_queries("hash_24_8", toplevel, &zstore.hashes3);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash_40_8", toplevel, &zstore.hashes5);
 
     let mut input = [F::zero(); 24];
     input[..16].copy_from_slice(&zptr.flatten());

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -505,3 +505,23 @@ test!(test_equal_non_num, "(= 'a 'a)", |_| ZPtr::err(
 test!(test_equal_non_num2, "(= (comm #0x0) (comm #0x0))", |_| {
     ZPtr::err(EvalErr::ArgNotNumber)
 });
+test!(
+    test_shadow_err1,
+    "(let ((nil 1)) (+ nil 1))",
+    |_| ZPtr::err(EvalErr::IllegalBindingVar)
+);
+test!(test_shadow_err2, "(letrec ((nil 1)) (+ nil 1))", |_| {
+    ZPtr::err(EvalErr::IllegalBindingVar)
+});
+test!(test_shadow_err3, "((lambda (nil) (+ nil 1)) 1)", |_| {
+    ZPtr::err(EvalErr::IllegalBindingVar)
+});
+test!(test_shadow_err4, "(let ((t 1)) (+ t 1))", |_| ZPtr::err(
+    EvalErr::IllegalBindingVar
+));
+test!(test_shadow_err5, "(letrec ((t 1)) (+ t 1))", |_| ZPtr::err(
+    EvalErr::IllegalBindingVar
+));
+test!(test_shadow_err6, "((lambda (t) (+ t 1)) 1)", |_| ZPtr::err(
+    EvalErr::IllegalBindingVar
+));

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -506,7 +506,7 @@ test_raw!(
         let cons = z.intern_symbol(&builtin_sym("cons"));
         let one = uint(1);
         assert_eq!(cons.tag, Tag::Builtin);
-        let mut cons_sym = cons.clone();
+        let mut cons_sym = cons;
         cons_sym.tag = Tag::Sym;
         let binding = z.intern_list([cons, one]);
         let bindings = z.intern_list([binding]);

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -52,9 +52,12 @@ fn run_test(
     config: BabyBearPoseidon2,
 ) {
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_24_8", toplevel, &zstore.hashes3);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
-    record.inject_inv_queries("hash_40_8", toplevel, &zstore.hashes5);
+    let hashes3 = std::mem::take(&mut zstore.hashes3_diff);
+    let hashes4 = std::mem::take(&mut zstore.hashes4_diff);
+    let hashes5 = std::mem::take(&mut zstore.hashes5_diff);
+    record.inject_inv_queries_owned("hash3", toplevel, hashes3);
+    record.inject_inv_queries_owned("hash4", toplevel, hashes4);
+    record.inject_inv_queries_owned("hash5", toplevel, hashes5);
 
     let mut input = [F::zero(); 24];
     input[..16].copy_from_slice(&zptr.flatten());

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::{
     chipset::{lurk_hasher, LurkChip},
     eval::{build_lurk_toplevel, EvalErr},
-    state::{lurk_sym, user_sym},
+    state::{builtin_sym, user_sym},
     symbol::Symbol,
     tag::Tag,
     zstore::{ZPtr, ZStore},
@@ -184,10 +184,6 @@ fn uint(u: u64) -> ZPtr<F> {
     ZPtr::u64(u)
 }
 
-fn intern_t(zstore: &mut ZStore<F, LurkChip>) -> ZPtr<F> {
-    zstore.intern_symbol(&lurk_sym("t"))
-}
-
 // self-evaluating
 test!(test_num, "1", |_| uint(1));
 test!(test_char, "'a'", |_| ZPtr::char('a'));
@@ -195,8 +191,8 @@ test!(test_str, "\"abc\"", |z| z.intern_string("abc"));
 test!(test_key, ":hi", |z| z.intern_symbol(&Symbol::key(&["hi"])));
 test!(test_u64, "1u64", |_| ZPtr::u64(1));
 test!(test_field_elem, "1n", |_| ZPtr::num(F::one()));
-test!(test_t, "t", intern_t);
-test!(test_nil, "nil", |z| z.intern_nil());
+test!(test_t, "t", |z| *z.t());
+test!(test_nil, "nil", |z| *z.nil());
 test_raw!(test_fun, trivial_id_fun, trivial_id_fun);
 test_raw!(test_comm, |_| ZPtr::null(Tag::Comm), |_| ZPtr::null(
     Tag::Comm
@@ -218,7 +214,7 @@ test!(test_app_err2, "((lambda () a) 2)", |_| ZPtr::err(
 test!(test_if, "(if 1 1 0)", |_| uint(1));
 test!(test_if2, "(if nil 1 0)", |_| uint(0));
 test!(test_if3, "(if 1 1)", |_| uint(1));
-test!(test_if4, "(if nil 1)", |z| z.intern_nil());
+test!(test_if4, "(if nil 1)", |z| *z.nil());
 test!(test_let, "(let ((x 0) (y 1)) x)", |_| uint(0));
 test!(test_let2, "(let ((x 0) (y 1)) y)", |_| uint(1));
 test!(test_add, "(+ 1 2)", |_| uint(3));
@@ -226,45 +222,45 @@ test!(test_sub, "(- 5 2)", |_| uint(3));
 test!(test_mul, "(* 2 3)", |_| uint(6));
 test!(test_div, "(/ 6 3)", |_| uint(2));
 test!(test_arith, "(+ (* 2 2) (* 2 3))", |_| uint(10));
-test!(test_num_eq, "(= 0 1)", |z| z.intern_nil());
-test!(test_num_eq2, "(= 1 1)", intern_t);
+test!(test_num_eq, "(= 0 1)", |z| *z.nil());
+test!(test_num_eq2, "(= 1 1)", |z| *z.t());
 test!(
     test_num_eq3,
     "(= 3844955657946763191 18057789389824918841)",
-    |z| z.intern_nil()
+    |z| *z.nil()
 );
 test!(
     test_num_eq4,
     "(= 3844955657946763191 3844955657946763191)",
-    intern_t
+    |z| *z.t()
 );
-test!(test_num_eq5, "(= 0n 1n)", |z| z.intern_nil());
-test!(test_num_eq6, "(= 1n 1n)", intern_t);
-test!(test_u64_order1, "(>= 0 1)", |z| z.intern_nil());
-test!(test_u64_order2, "(>= 1 1)", intern_t);
-test!(test_u64_order3, "(>= 2 1)", intern_t);
-test!(test_u64_order4, "(<= 0 1)", intern_t);
-test!(test_u64_order5, "(<= 1 1)", intern_t);
-test!(test_u64_order6, "(<= 2 1)", |z| z.intern_nil());
-test!(test_u64_order7, "(> 0 1)", |z| z.intern_nil());
-test!(test_u64_order8, "(> 1 1)", |z| z.intern_nil());
-test!(test_u64_order9, "(> 2 1)", intern_t);
-test!(test_u64_order10, "(< 0 1)", intern_t);
-test!(test_u64_order11, "(< 1 1)", |z| z.intern_nil());
-test!(test_u64_order12, "(< 2 1)", |z| z.intern_nil());
+test!(test_num_eq5, "(= 0n 1n)", |z| *z.nil());
+test!(test_num_eq6, "(= 1n 1n)", |z| *z.t());
+test!(test_u64_order1, "(>= 0 1)", |z| *z.nil());
+test!(test_u64_order2, "(>= 1 1)", |z| *z.t());
+test!(test_u64_order3, "(>= 2 1)", |z| *z.t());
+test!(test_u64_order4, "(<= 0 1)", |z| *z.t());
+test!(test_u64_order5, "(<= 1 1)", |z| *z.t());
+test!(test_u64_order6, "(<= 2 1)", |z| *z.nil());
+test!(test_u64_order7, "(> 0 1)", |z| *z.nil());
+test!(test_u64_order8, "(> 1 1)", |z| *z.nil());
+test!(test_u64_order9, "(> 2 1)", |z| *z.t());
+test!(test_u64_order10, "(< 0 1)", |z| *z.t());
+test!(test_u64_order11, "(< 1 1)", |z| *z.nil());
+test!(test_u64_order12, "(< 2 1)", |z| *z.nil());
 test!(
     test_u64_order13,
     "(< 3844955657946763191 18057789389824918841)",
-    intern_t
+    |z| *z.t()
 );
 test!(
     test_u64_order14,
     "(<= 3844955657946763191 3844955657946763191)",
-    intern_t
+    |z| *z.t()
 );
-test!(test_begin_empty, "(begin)", |z| z.intern_nil());
+test!(test_begin_empty, "(begin)", |z| *z.nil());
 test!(test_begin, "(begin 1 2 3)", |_| uint(3));
-test!(test_list, "(list)", |z| z.intern_nil());
+test!(test_list, "(list)", |z| *z.nil());
 test!(test_list2, "(list (+ 1 1) \"hi\")", |z| {
     let hi = z.intern_string("hi");
     let two = uint(2);
@@ -288,62 +284,58 @@ test!(test_car, "(car (cons 0 1))", |_| uint(0));
 test!(test_cdr, "(cdr (cons 0 1))", |_| uint(1));
 test!(test_strcons, "(strcons 'a' \"bc\")", |z| z
     .intern_string("abc"));
-test!(test_eq1, "(eq (cons 1 2) '(1 . 2))", intern_t);
-test!(test_eq2, "(eq (cons 1 3) '(1 . 2))", |z| z.intern_nil());
-test!(test_eq3, "(eq :a :a)", intern_t);
-test!(test_eq4, "(eq :a :b)", |z| z.intern_nil());
-test!(test_eq5, "(eq 'a 'a)", intern_t);
-test!(test_eq6, "(eq 'a 'b)", |z| z.intern_nil());
-test!(test_eq7, "(eq nil nil)", intern_t);
-test!(test_eq8, "(eq t t)", intern_t);
-test!(test_eq9, "(eq t nil)", |z| z.intern_nil());
-test!(test_eq10, "(eq 'a' 'b')", |z| z.intern_nil());
-test!(test_eq11, "(eq 'a' 'a')", intern_t);
-test!(test_eq12, "(eq \"abc\" \"abd\")", |z| z.intern_nil());
-test!(test_eq13, "(eq \"abc\" \"abc\")", intern_t);
-test!(test_eq14, "(eq (cons 'a 1) (cons 'a 2))", |z| z
-    .intern_nil());
-test!(test_eq15, "(eq (cons :a 1) (cons :a 1))", intern_t);
-test!(test_eq16, "(eq (lambda (x) x) (lambda (x) x))", intern_t);
-test!(test_eq17, "(eq (lambda (x) x) (lambda (y) y))", |z| z
-    .intern_nil());
+test!(test_eq1, "(eq (cons 1 2) '(1 . 2))", |z| *z.t());
+test!(test_eq2, "(eq (cons 1 3) '(1 . 2))", |z| *z.nil());
+test!(test_eq3, "(eq :a :a)", |z| *z.t());
+test!(test_eq4, "(eq :a :b)", |z| *z.nil());
+test!(test_eq5, "(eq 'a 'a)", |z| *z.t());
+test!(test_eq6, "(eq 'a 'b)", |z| *z.nil());
+test!(test_eq7, "(eq nil nil)", |z| *z.t());
+test!(test_eq8, "(eq t t)", |z| *z.t());
+test!(test_eq9, "(eq t nil)", |z| *z.nil());
+test!(test_eq10, "(eq 'a' 'b')", |z| *z.nil());
+test!(test_eq11, "(eq 'a' 'a')", |z| *z.t());
+test!(test_eq12, "(eq \"abc\" \"abd\")", |z| *z.nil());
+test!(test_eq13, "(eq \"abc\" \"abc\")", |z| *z.t());
+test!(test_eq14, "(eq (cons 'a 1) (cons 'a 2))", |z| *z.nil());
+test!(test_eq15, "(eq (cons :a 1) (cons :a 1))", |z| *z.t());
+test!(test_eq16, "(eq (lambda (x) x) (lambda (x) x))", |z| *z.t());
+test!(test_eq17, "(eq (lambda (x) x) (lambda (y) y))", |z| *z
+    .nil());
 test!(
     test_eq18,
     "(eq (let ((x 1)) (current-env)) (let ((x 1)) (current-env)))",
-    intern_t
+    |z| *z.t()
 );
 test!(
     test_eq19,
     "(eq (let ((x 1)) (current-env)) (current-env))",
-    |z| z.intern_nil()
+    |z| *z.nil()
 );
 test_raw!(
     test_eq20,
     |z| {
-        let eq = z.intern_symbol(&lurk_sym("eq"));
-        let t = z.intern_symbol(&lurk_sym("t"));
+        let eq = z.intern_symbol(&builtin_sym("eq"));
         let env = z.intern_empty_env();
-        let arg1 = z.intern_thunk(t, env);
-        let arg2 = z.intern_thunk(t, env);
+        let arg1 = z.intern_thunk(*z.t(), env);
+        let arg2 = z.intern_thunk(*z.t(), env);
         z.intern_list([eq, arg1, arg2])
     },
-    intern_t
+    |z| *z.t()
 );
 test_raw!(
     test_eq21,
     |z| {
-        let eq = z.intern_symbol(&lurk_sym("eq"));
-        let nil = z.intern_nil();
-        let t = z.intern_symbol(&lurk_sym("t"));
+        let eq = z.intern_symbol(&builtin_sym("eq"));
         let env = z.intern_empty_env();
-        let arg1 = z.intern_thunk(nil, env);
-        let arg2 = z.intern_thunk(t, env);
+        let arg1 = z.intern_thunk(*z.nil(), env);
+        let arg2 = z.intern_thunk(*z.t(), env);
         z.intern_list([eq, arg1, arg2])
     },
-    |z| z.intern_nil()
+    |z| *z.nil()
 );
-test!(test_eq22, "(eq 1n 0n)", |z| z.intern_nil());
-test!(test_eq23, "(eq 1n 1n)", intern_t);
+test!(test_eq22, "(eq 1n 0n)", |z| *z.nil());
+test!(test_eq23, "(eq 1n 1n)", |z| *z.t());
 
 test!(
     test_misc1,
@@ -351,11 +343,11 @@ test!(
        (car ((cdr ones))))",
     |_| uint(1)
 );
-test!(test_type_eq1, "(type-eq 1 (+ 1 2))", intern_t);
-test!(test_type_eq2, "(type-eq (+ 1 1) 'a')", |z| z.intern_nil());
-test!(test_type_eqq1, "(type-eqq (nil) (cons 1 2))", intern_t);
-test!(test_type_eqq2, "(type-eqq 2 'a')", |z| z.intern_nil());
-test!(test_breakpoint, "(breakpoint)", |z| z.intern_nil());
+test!(test_type_eq1, "(type-eq 1 (+ 1 2))", |z| *z.t());
+test!(test_type_eq2, "(type-eq (+ 1 1) 'a')", |z| *z.nil());
+test!(test_type_eqq1, "(type-eqq (nil) (cons 1 2))", |z| *z.t());
+test!(test_type_eqq2, "(type-eqq 2 'a')", |z| *z.nil());
+test!(test_breakpoint, "(breakpoint)", |z| *z.nil());
 test!(test_breakpoint2, "(breakpoint (+ 1 1))", |_| uint(2));
 
 // coercions
@@ -416,7 +408,7 @@ test!(test_hide2, "(hide (commit 321) 123)", |_| ZPtr::err(
 test!(test_open_roundtrip, "(open (commit 123))", |_| uint(123));
 test!(
     test_open_raw_roundtrip,
-    "(begin (commit 123n) (open #0x4b51f7ca76e9700190d753b328b34f3f59e0ad3c70c486645b5890068862f3))",
+    "(begin (commit 123n) (open #0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882))",
     |_| ZPtr::num(F::from_canonical_u32(123))
 );
 test!(test_secret, "(secret (commit 123))", |_| ZPtr::big_num(
@@ -424,12 +416,12 @@ test!(test_secret, "(secret (commit 123))", |_| ZPtr::big_num(
 ));
 test!(
     test_func_big_num_app,
-    "(begin (commit (lambda (x) x)) (#0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a 42))",
+    "(begin (commit (lambda (x) x)) (#0x629c897f61a5642e960a29514399063940eda913d91e90396c98287cbfa0f4 42))",
     |_| uint(42)
 );
 test!(
     test_func_comm_app,
-    "(begin (commit (lambda (x) x)) ((comm #0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a) 42))",
+    "(begin (commit (lambda (x) x)) ((comm #0x629c897f61a5642e960a29514399063940eda913d91e90396c98287cbfa0f4) 42))",
     |_| uint(42)
 );
 
@@ -438,7 +430,7 @@ test!(test_raw_big_num, "#0x0", |_| ZPtr::big_num([F::zero(); 8]));
 test!(test_raw_comm, "#c0x0", |_| ZPtr::comm([F::zero(); 8]));
 test!(
     test_raw_big_num2,
-    "#0x4b51f7ca76e9700190d753b328b34f3f59e0ad3c70c486645b5890068862f3",
+    "#0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882",
     |_| {
         let mut preimg = Vec::with_capacity(24);
         preimg.extend([F::zero(); 8]);
@@ -448,7 +440,7 @@ test!(
 );
 test!(
     test_raw_comm2,
-    "#c0x4b51f7ca76e9700190d753b328b34f3f59e0ad3c70c486645b5890068862f3",
+    "#c0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882",
     |_| {
         let mut preimg = Vec::with_capacity(24);
         preimg.extend([F::zero(); 8]);
@@ -472,24 +464,32 @@ test!(
     "(comm (bignum #c0x0))",
     |_| ZPtr::comm([F::zero(); 8])
 );
-test!(test_big_num_equal1, "(= #0x0 #0x1)", |z| z.intern_nil());
-test!(test_big_num_equal2, "(= #0x0 #0x0)", intern_t);
-test!(test_big_num_order1, "(>= #0x0 #0x1)", |z| z.intern_nil());
-test!(test_big_num_order2, "(>= #0x1 #0x1)", intern_t);
-test!(test_big_num_order3, "(>= #0x2 #0x1)", intern_t);
-test!(test_big_num_order4, "(<= #0x0 #0x1)", intern_t);
-test!(test_big_num_order5, "(<= #0x1 #0x1)", intern_t);
-test!(test_big_num_order6, "(<= #0x2 #0x1)", |z| z.intern_nil());
-test!(test_big_num_order7, "(> #0x0 #0x1)", |z| z.intern_nil());
-test!(test_big_num_order8, "(> #0x1 #0x1)", |z| z.intern_nil());
-test!(test_big_num_order9, "(> #0x2 #0x1)", intern_t);
-test!(test_big_num_order10, "(< #0x0 #0x1)", intern_t);
-test!(test_big_num_order11, "(< #0x1 #0x1)", |z| z.intern_nil());
-test!(test_big_num_order12, "(< #0x2 #0x1)", |z| z.intern_nil());
-test!(test_big_num_order13, "(< #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x7b4dd31c2678ef3c257cda6a06f0c830aaeab011c2c4e7fa9a27c699550539)", intern_t);
-test!(test_big_num_order14, "(<= #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7)", intern_t);
-test!(test_big_num_order15, "(eq #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x7b4dd31c2678ef3c257cda6a06f0c830aaeab011c2c4e7fa9a27c699550539)", |z| z.intern_nil());
-test!(test_big_num_order16, "(eq #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7)", intern_t);
+test!(test_big_num_equal1, "(= #0x0 #0x1)", |z| *z.nil());
+test!(test_big_num_equal2, "(= #0x0 #0x0)", |z| *z.t());
+test!(test_big_num_order1, "(>= #0x0 #0x1)", |z| *z.nil());
+test!(test_big_num_order2, "(>= #0x1 #0x1)", |z| *z.t());
+test!(test_big_num_order3, "(>= #0x2 #0x1)", |z| *z.t());
+test!(test_big_num_order4, "(<= #0x0 #0x1)", |z| *z.t());
+test!(test_big_num_order5, "(<= #0x1 #0x1)", |z| *z.t());
+test!(test_big_num_order6, "(<= #0x2 #0x1)", |z| *z.nil());
+test!(test_big_num_order7, "(> #0x0 #0x1)", |z| *z.nil());
+test!(test_big_num_order8, "(> #0x1 #0x1)", |z| *z.nil());
+test!(test_big_num_order9, "(> #0x2 #0x1)", |z| *z.t());
+test!(test_big_num_order10, "(< #0x0 #0x1)", |z| *z.t());
+test!(test_big_num_order11, "(< #0x1 #0x1)", |z| *z.nil());
+test!(test_big_num_order12, "(< #0x2 #0x1)", |z| *z.nil());
+test!(test_big_num_order13, "(< #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x7b4dd31c2678ef3c257cda6a06f0c830aaeab011c2c4e7fa9a27c699550539)", |z| *z.t());
+test!(test_big_num_order14, "(<= #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7)", |z| *z.t());
+test!(test_big_num_order15, "(eq #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x7b4dd31c2678ef3c257cda6a06f0c830aaeab011c2c4e7fa9a27c699550539)", |z| *z.nil());
+test!(test_big_num_order16, "(eq #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7 #0x17084a3b94580234614c1ebde7dbb24bc3cb26ba2a84d1355c06cca90b8fb7)", |z| *z.t());
+
+// shadowing built-ins
+test!(test_shadow1, "(let ((cons 1)) (+ cons 1))", |_| uint(2));
+test!(test_shadow2, "(letrec ((cons 1)) (+ cons 1))", |_| uint(2));
+test!(test_shadow3, "((lambda (cons) (+ cons 1)) 1)", |_| uint(2));
+test!(test_shadow4, "(let ((cons 1)) (cons cons cons))", |z| {
+    z.intern_cons(uint(1), uint(1))
+});
 
 // errors
 test!(test_unbound_var, "a", |_| ZPtr::err(EvalErr::UnboundVar));

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -52,9 +52,9 @@ fn run_test(
     config: BabyBearPoseidon2,
 ) {
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_24_8", toplevel, &zstore.hashes3);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
-    record.inject_inv_queries("hash_48_8", toplevel, &zstore.hashes6);
+    record.inject_inv_queries("hash_24_8", toplevel, &zstore.hashes24);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
+    record.inject_inv_queries("hash_40_8", toplevel, &zstore.hashes40);
 
     let mut input = [F::zero(); 24];
     input[..16].copy_from_slice(&zptr.flatten());
@@ -416,12 +416,12 @@ test!(test_secret, "(secret (commit 123))", |_| ZPtr::big_num(
 ));
 test!(
     test_func_big_num_app,
-    "(begin (commit (lambda (x) x)) (#0x629c897f61a5642e960a29514399063940eda913d91e90396c98287cbfa0f4 42))",
+    "(begin (commit (lambda (x) x)) (#0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 42))",
     |_| uint(42)
 );
 test!(
     test_func_comm_app,
-    "(begin (commit (lambda (x) x)) ((comm #0x629c897f61a5642e960a29514399063940eda913d91e90396c98287cbfa0f4) 42))",
+    "(begin (commit (lambda (x) x)) ((comm #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc) 42))",
     |_| uint(42)
 );
 

--- a/src/lurk/package.rs
+++ b/src/lurk/package.rs
@@ -1,8 +1,6 @@
 use anyhow::{bail, Result};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
 
 use super::symbol::Symbol;
 
@@ -11,9 +9,9 @@ pub(crate) type SymbolRef = Arc<Symbol>;
 #[derive(Debug)]
 pub struct Package {
     name: SymbolRef,
-    symbols: HashMap<String, SymbolRef>,
-    names: HashMap<SymbolRef, String>,
-    local: HashSet<SymbolRef>,
+    symbols: FxHashMap<String, SymbolRef>,
+    names: FxHashMap<SymbolRef, String>,
+    local: FxHashSet<SymbolRef>,
 }
 
 impl Package {

--- a/src/lurk/tag.rs
+++ b/src/lurk/tag.rs
@@ -8,21 +8,21 @@ use serde::{Deserialize, Serialize};
     Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, FromPrimitive,
 )]
 pub enum Tag {
-    Nil = 0,
-    Cons,
-    Sym,
-    Fun,
+    U64 = 2, // 0 and 1 are reserved for nil and t inside the vm
     Num,
-    Str,
-    Char,
-    Comm,
-    U64,
-    Key,
-    Env,
-    Err,
-    Thunk,
-    Builtin,
     BigNum,
+    Comm,
+    Char,
+    Str,
+    Key,
+    Fun,
+    Builtin,
+    Sym,
+    Cons,
+    Env,
+    Thunk,
+    Err,
+    Nil, // delete me
 }
 
 impl Tag {
@@ -57,7 +57,6 @@ mod test {
     #[test]
     fn test_tag_index_roundtrip() {
         for tag in [
-            Tag::Nil,
             Tag::Cons,
             Tag::Sym,
             Tag::Fun,

--- a/src/lurk/tag.rs
+++ b/src/lurk/tag.rs
@@ -22,7 +22,6 @@ pub enum Tag {
     Env,
     Thunk,
     Err,
-    Nil, // delete me
 }
 
 impl Tag {

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -668,7 +668,6 @@ impl<F: Field, H: Chipset<F>> ZStore<F, H> {
             };
         }
         match tag {
-            Tag::Nil => panic!("delete me"),
             Tag::Str => loop {
                 if digest == zeros {
                     self.memoize_atom_dag(ZPtr { tag, digest: zeros });
@@ -889,7 +888,6 @@ impl<F: Field, H: Chipset<F>> ZStore<F, H> {
         F: PrimeField32,
     {
         match zptr.tag {
-            Tag::Nil => panic!("delete me"),
             Tag::Num => format!("{}n", zptr.digest[0]),
             Tag::U64 => format!(
                 "{}",

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -38,7 +38,7 @@ pub(crate) const HASH3_SIZE: usize = DIGEST_SIZE + ZPTR_SIZE;
 pub(crate) const HASH4_SIZE: usize = 2 * ZPTR_SIZE;
 
 const COMPACT10_SIZE: usize = ZPTR_SIZE + DIGEST_SIZE;
-const COMPACT110_SIZE: usize = 2 * ZPTR_SIZE + DIGEST_SIZE;
+pub(crate) const COMPACT110_SIZE: usize = 2 * ZPTR_SIZE + DIGEST_SIZE;
 
 fn digest_from_field<F: AbstractField + Copy>(f: F) -> [F; DIGEST_SIZE] {
     let mut digest = [F::zero(); DIGEST_SIZE];

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -58,7 +58,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -58,7 +58,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -58,7 +58,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes32);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();


### PR DESCRIPTION
* Built-ins now live in `.lurk.builtin`
* `nil` and `t` are now tagged as `Tag::Sym`
* User symbols now live in `.lurk-user`
* Factor out `eval_builtin_expr` from `eval`
* Allow built-ins as binding variables
* Get rid of `Tag::Nil`

Closes #213 