### PR TITLE
feat: Add support for `&rest` parameters and `apply` as a built-in

### DIFF
--- a/lib/util.lurk
+++ b/lib/util.lurk
@@ -73,13 +73,6 @@
                          (revappend (cdr x) (cons (car x) y))
                          y)))
 
-!(defrec apply (lambda (f args)
-                 (if args
-                     (if (cdr args)
-                         (apply (f (car args)) (cdr args))
-                         (f (car args)))
-                     (f))))
-
 !(def getf (lambda (plist indicator)
              (letrec ((aux (lambda (plist)
                              (if plist

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -127,7 +127,7 @@ fn native_lurk_funcs<F: PrimeField32>(
         car_cdr(digests),
         eval_let(),
         eval_letrec(),
-        apply(&digests),
+        apply(digests),
         env_lookup(),
         ingress(digests),
         egress(digests),
@@ -2107,7 +2107,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                     // check if the only params left are "&rest <var>"
                     let (param_tag, param, rest_params_tag, rest_params) = load(params);
                     match param_tag {
-                        Tag::Sym, Tag::Builtin => {
+                        Tag::Sym, Tag::Builtin, Tag::Coroutine => {
                             let rest_sym = digests.lurk_symbol_ptr("&rest");
                             let is_not_rest_sym = sub(param, rest_sym);
                             if !is_not_rest_sym {
@@ -2120,7 +2120,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                                     Tag::Cons => {
                                         let (param_tag, param, rest_params_tag, rest_params) = load(rest_params);
                                         match param_tag {
-                                            Tag::Sym, Tag::Builtin => {
+                                            Tag::Sym, Tag::Builtin, Tag::Coroutine => {
                                                 match rest_params_tag {
                                                     InternalTag::Nil => {
                                                         // evaluate all the remaining arguments and collect into a list
@@ -2161,7 +2161,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                                 Tag::Cons => {
                                     let (arg_tag, arg, rest_args_tag, rest_args) = load(args);
                                     match param_tag {
-                                        Tag::Sym, Tag::Builtin => {
+                                        Tag::Sym, Tag::Builtin, Tag::Coroutine => {
                                             // evaluate the argument
                                             let (arg_tag, arg) = call(eval, arg_tag, arg, args_env);
                                             match arg_tag {
@@ -2325,7 +2325,7 @@ mod test {
         expect_eq(equal.width(), expect!["82"]);
         expect_eq(equal_inner.width(), expect!["59"]);
         expect_eq(car_cdr.width(), expect!["61"]);
-        expect_eq(apply.width(), expect!["114"]);
+        expect_eq(apply.width(), expect!["115"]);
         expect_eq(env_lookup.width(), expect!["52"]);
         expect_eq(ingress.width(), expect!["105"]);
         expect_eq(egress.width(), expect!["82"]);

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -2107,7 +2107,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                             let rest_sym = digests.lurk_symbol_ptr("&rest");
                             let is_not_rest_sym = sub(param, rest_sym);
                             if !is_not_rest_sym {
-                                // check the next param in the list
+                                // check whether the next param in the list is a variable
                                 match rest_params_tag {
                                     InternalTag::Nil => {
                                         let err = EvalErr::ParamInvalidRest;
@@ -2117,6 +2117,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                                         let (param_tag, param, rest_params_tag, rest_params) = load(rest_params);
                                         match param_tag {
                                             Tag::Sym, Tag::Builtin, Tag::Coroutine => {
+                                                // check that there are no remaining arguments after the variable
                                                 match rest_params_tag {
                                                     InternalTag::Nil => {
                                                         // evaluate all the remaining arguments and collect into a list
@@ -2148,7 +2149,8 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                                 let err = EvalErr::ParamsNotList;
                                 return (err_tag, err)
                             }
-                            // FIXME: this is the same as the code below
+                            // NOTE: the two block of codes below delimited by the comments are the *exact* same and *must* be kept in sync
+                            // --- DUPLICATED BLOCK ---
                             match args_tag {
                                 InternalTag::Nil => {
                                     // Undersaturated application
@@ -2179,8 +2181,10 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                             };
                             let err = EvalErr::ArgsNotList;
                             return (err_tag, err)
+                            // --- DUPLICATED BLOCK ---
                         }
                     };
+                    // --- DUPLICATED BLOCK ---
                     match args_tag {
                         InternalTag::Nil => {
                             // Undersaturated application
@@ -2211,6 +2215,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                     };
                     let err = EvalErr::ArgsNotList;
                     return (err_tag, err)
+                    // --- DUPLICATED BLOCK ---
                 }
             };
             let err = EvalErr::ParamsNotList;

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1193,6 +1193,36 @@ pub fn eval_builtin_expr<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE
                     let (res_tag, res) = call(eval_opening_unop, head, rest_tag, rest, env);
                     return (res_tag, res)
                 }
+                "apply" => {
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (fst_tag, fst, rest_tag, rest) = load(rest);
+                    let rest_not_cons = sub(rest_tag, cons_tag);
+                    if rest_not_cons {
+                        return (err_tag, invalid_form)
+                    }
+                    let (fst_tag, fst) = call(eval, fst_tag, fst, env);
+                    match fst_tag {
+                        Tag::Err => {
+                            return (fst_tag, fst)
+                        }
+                    };
+                    let (snd_tag, snd, rest_tag, _rest) = load(rest);
+                    let rest_not_nil = sub(rest_tag, nil_tag);
+                    if rest_not_nil {
+                        return (err_tag, invalid_form)
+                    }
+                    let (snd_tag, snd) = call(eval, snd_tag, snd, env);
+                    match snd_tag {
+                        Tag::Err => {
+                            return (snd_tag, snd)
+                        }
+                    };
+                    let (res_tag, res) = call(apply, fst_tag, fst, snd_tag, snd, env);
+                    return (res_tag, res)
+                }
                 // TODO: other built-ins
             }
         }

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -2150,7 +2150,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                                 return (err_tag, err)
                             }
                             // NOTE: the two block of codes below delimited by the comments are the *exact* same and *must* be kept in sync
-                            // --- DUPLICATED BLOCK ---
+                            // --- DUPLICATED APPLY BLOCK START ---
                             match args_tag {
                                 InternalTag::Nil => {
                                     // Undersaturated application
@@ -2181,10 +2181,10 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                             };
                             let err = EvalErr::ArgsNotList;
                             return (err_tag, err)
-                            // --- DUPLICATED BLOCK ---
+                            // --- DUPLICATED APPLY BLOCK END ---
                         }
                     };
-                    // --- DUPLICATED BLOCK ---
+                    // --- DUPLICATED APPLY BLOCK START ---
                     match args_tag {
                         InternalTag::Nil => {
                             // Undersaturated application
@@ -2215,7 +2215,7 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                     };
                     let err = EvalErr::ArgsNotList;
                     return (err_tag, err)
-                    // --- DUPLICATED BLOCK ---
+                    // --- DUPLICATED APPLY BLOCK END ---
                 }
             };
             let err = EvalErr::ParamsNotList;

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -263,7 +263,7 @@ const USER_PACKAGE_NAME: &str = "lurk-user";
 
 pub(crate) const LURK_SYMBOLS: [&str; 3] = ["nil", "t", "&rest"];
 
-pub(crate) const BUILTIN_SYMBOLS: [&str; 39] = [
+pub(crate) const BUILTIN_SYMBOLS: [&str; 40] = [
     "atom",
     "apply",
     "begin",

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -265,6 +265,7 @@ pub(crate) const LURK_SYMBOLS: [&str; 2] = ["nil", "t"];
 
 pub(crate) const BUILTIN_SYMBOLS: [&str; 39] = [
     "atom",
+    "apply",
     "begin",
     "car",
     "cdr",

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -261,7 +261,7 @@ const BUILTIN_PACKAGE_NAME: &str = "builtin";
 const META_PACKAGE_NAME: &str = "meta";
 const USER_PACKAGE_NAME: &str = "lurk-user";
 
-pub(crate) const LURK_SYMBOLS: [&str; 2] = ["nil", "t"];
+pub(crate) const LURK_SYMBOLS: [&str; 3] = ["nil", "t", "&rest"];
 
 pub(crate) const BUILTIN_SYMBOLS: [&str; 39] = [
     "atom",

--- a/src/lurk/tests/eval.rs
+++ b/src/lurk/tests/eval.rs
@@ -188,6 +188,9 @@ test!(test_app_err, "(a)", |_| ZPtr::err(EvalErr::UnboundVar));
 test!(test_app_err2, "((lambda () a) 2)", |_| ZPtr::err(
     EvalErr::UnboundVar
 ));
+test!(test_app_err3, "(apply (lambda (x) x) 1)", |_| ZPtr::err(
+    EvalErr::ArgsNotList
+));
 
 // builtins
 test!(test_if, "(if 1 1 0)", |_| uint(1));

--- a/src/lurk/tests/eval.rs
+++ b/src/lurk/tests/eval.rs
@@ -494,6 +494,12 @@ test!(
     "((lambda (&rest &rest) (car &rest)) 1 2 5)",
     |_| uint(1)
 );
+test!(test_shadow7, "(let ((&rest 1)) &rest)", |_| uint(1));
+test!(
+    test_shadow8,
+    "(let ((&rest (lambda (x) x))) (&rest 1))",
+    |_| uint(1)
+);
 
 // errors
 test!(test_unbound_var, "a", |_| ZPtr::err(EvalErr::UnboundVar));

--- a/src/lurk/tests/eval.rs
+++ b/src/lurk/tests/eval.rs
@@ -160,6 +160,30 @@ test!(test_app2, "((lambda (x y z) y) 1 2 3)", |_| uint(2));
 test!(test_app3, "((lambda (x) (lambda (y) x)) 1 2)", |_| {
     uint(1)
 });
+test!(test_app4, "(apply (lambda (x) x) '(1))", |_| uint(1));
+test!(test_app5, "(apply (lambda (x y z) y) (list 1 2 3))", |_| {
+    uint(2)
+});
+test!(
+    test_app6,
+    "(apply (lambda (x) (lambda (y) x)) '(1 2))",
+    |_| { uint(1) }
+);
+test!(test_app7, "((lambda (x &rest y) (car (cdr y))) 1)", |z| *z
+    .nil());
+test!(test_app8, "((lambda (x &rest y) (car (cdr y))) 1 2)", |z| {
+    *z.nil()
+});
+test!(
+    test_app9,
+    "((lambda (x &rest y) (car (cdr y))) 1 2 3)",
+    |_| uint(3)
+);
+test!(
+    test_app10,
+    "((lambda (x &rest y) (car (cdr y))) 1 2 3 4)",
+    |_| uint(3)
+);
 test!(test_app_err, "(a)", |_| ZPtr::err(EvalErr::UnboundVar));
 test!(test_app_err2, "((lambda () a) 2)", |_| ZPtr::err(
     EvalErr::UnboundVar
@@ -340,7 +364,15 @@ test!(
             (if (= n 0) 0
               (if (= n 1) 1
                 (+ (fib (- n 1)) (fib (- n 2))))))))
-        (fib 10))",
+       (fib 10))",
+    |_| uint(55)
+);
+test!(
+    test_sum,
+    "(letrec ((sum
+          (lambda (x &rest y)
+            (if y (+ x (apply sum y)) x))))
+       (sum 1 2 3 4 5 6 7 8 9 10))",
     |_| uint(55)
 );
 
@@ -449,6 +481,16 @@ test!(test_shadow3, "((lambda (cons) (+ cons 1)) 1)", |_| uint(2));
 test!(test_shadow4, "(let ((cons 1)) (cons cons cons))", |z| {
     z.intern_cons(uint(1), uint(1))
 });
+test!(
+    test_shadow5,
+    "((lambda (cons &rest car) (+ cons (car car))) 1 2 5)",
+    |_| uint(3)
+);
+test!(
+    test_shadow6,
+    "((lambda (&rest &rest) (car &rest)) 1 2 5)",
+    |_| uint(1)
+);
 
 // errors
 test!(test_unbound_var, "a", |_| ZPtr::err(EvalErr::UnboundVar));
@@ -501,3 +543,23 @@ test!(test_shadow_err5, "(letrec ((t 1)) (+ t 1))", |_| ZPtr::err(
 test!(test_shadow_err6, "((lambda (t) (+ t 1)) 1)", |_| ZPtr::err(
     EvalErr::IllegalBindingVar
 ));
+test!(test_shadow_err7, "((lambda (x &rest t) (+ x 1)) 1)", |_| {
+    ZPtr::err(EvalErr::IllegalBindingVar)
+});
+test!(
+    test_shadow_err8,
+    "((lambda (x &rest nil) (+ x 1)) 1)",
+    |_| ZPtr::err(EvalErr::IllegalBindingVar)
+);
+test!(test_rest_err1, "((lambda (x &rest) x) 1)", |_| ZPtr::err(
+    EvalErr::ParamInvalidRest
+));
+test!(test_rest_err2, "((lambda (x &rest y z) x) 1)", |_| {
+    ZPtr::err(EvalErr::ParamInvalidRest)
+});
+test!(test_rest_err3, "((lambda (&rest y z) z) 1)", |_| ZPtr::err(
+    EvalErr::ParamInvalidRest
+));
+test!(test_rest_err4, "((lambda (&rest) &rest) 1)", |_| {
+    ZPtr::err(EvalErr::ParamInvalidRest)
+});

--- a/src/lurk/tests/lang.rs
+++ b/src/lurk/tests/lang.rs
@@ -236,3 +236,14 @@ test!(
     "((lambda (extern-square) (+ extern-square 1n)) 2n)",
     |_| num(3)
 );
+
+test!(
+    test_mul_shadow4,
+    "((lambda (&rest mul-square) (+ (car mul-square) 1n)) 2n)",
+    |_| num(3)
+);
+test!(
+    test_extern_shadow4,
+    "((lambda (&rest extern-square) (+ (car extern-square) 1n)) 2n)",
+    |_| num(3)
+);


### PR DESCRIPTION
This PR adds:

* `apply` builtin: `(apply f args)` will call `f` passing the arguments from the `args` list. For example, `(apply (lambda (x y) (+ x y)) (list 1 2))`
* Support for `&rest` parameters in function definitions, allowing for variadic functions. For example, `(lambda (x &rest y) ...)`

There is some unfortunate code duplication in `apply`, but this solution is better (in terms of columns and code complexity) for now. We might be able to simplify the duplication out in the future.

Manual update: https://github.com/argumentcomputer/user-manual/pull/24