### PR TITLE
feat: micro-chain simulator

### DIFF
--- a/src/lurk/cli/lurk_data.rs
+++ b/src/lurk/cli/lurk_data.rs
@@ -10,7 +10,7 @@ use super::zdag::ZDag;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct LurkData<F: std::hash::Hash + Eq> {
-    zptr: ZPtr<F>,
+    pub(crate) zptr: ZPtr<F>,
     zdag: ZDag<F>,
 }
 
@@ -30,5 +30,10 @@ impl<F: std::hash::Hash + Eq + Default + Copy> LurkData<F> {
         let Self { zptr, zdag } = self;
         zdag.populate_zstore(zstore);
         zptr
+    }
+
+    #[inline]
+    pub(crate) fn has_opaque_data(&self) -> bool {
+        self.zdag.has_opaque_data(&self.zptr)
     }
 }

--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -1237,7 +1237,7 @@ impl<H: Chipset<F>> MetaCmd<F, H> {
             let stream = &mut TcpStream::connect(addr_str)?;
             write_data(stream, Request::Get)?;
             let Response::State(chain_result, next_callable) = read_data(stream)? else {
-                unreachable!()
+                bail!("Could not read state from server");
             };
             let state_chain_result = chain_result.populate_zstore(&mut repl.zstore);
             let state_next_callable = next_callable.commit(&mut repl.zstore);

--- a/src/lurk/cli/proofs.rs
+++ b/src/lurk/cli/proofs.rs
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 
-use super::{lurk_data::LurkData, zdag::ZDag};
+use super::{comm_data::CommData, lurk_data::LurkData, zdag::ZDag};
 
 #[derive(Serialize, Deserialize)]
 struct CryptoShardProof {
@@ -200,5 +200,6 @@ impl ProtocolProof {
 pub(crate) struct ChainProof {
     pub(crate) crypto_proof: CryptoProof,
     pub(crate) call_args: ZPtr<F>,
-    pub(crate) next_state: LurkData<F>,
+    pub(crate) chain_result: LurkData<F>,
+    pub(crate) next_callable: CommData<F>,
 }

--- a/src/lurk/cli/proofs.rs
+++ b/src/lurk/cli/proofs.rs
@@ -36,6 +36,11 @@ pub(crate) struct CryptoProof {
 
 type F = BabyBear;
 
+#[inline]
+pub(crate) fn get_verifier_version() -> &'static str {
+    env!("VERGEN_GIT_SHA")
+}
+
 impl CryptoProof {
     #[inline]
     pub(crate) fn into_machine_proof(
@@ -73,7 +78,7 @@ impl CryptoProof {
 
     #[inline]
     pub(crate) fn has_same_verifier_version(&self) -> bool {
-        self.verifier_version == env!("VERGEN_GIT_SHA")
+        self.verifier_version == get_verifier_version()
     }
 }
 
@@ -189,4 +194,11 @@ impl ProtocolProof {
             args: LurkData::new(args, zstore),
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ChainProof {
+    pub(crate) crypto_proof: CryptoProof,
+    pub(crate) call_args: ZPtr<F>,
+    pub(crate) next_state: LurkData<F>,
 }

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -84,4 +84,18 @@ impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
             zstore.dag.insert(zptr, zptr_type);
         }
     }
+
+    /// Whether there's data missing in the ZDag or not
+    pub(crate) fn has_opaque_data(&self, zptr: &ZPtr<F>) -> bool {
+        match self.0.get(zptr) {
+            None => true,
+            Some(ZPtrType::Atom) => false,
+            Some(ZPtrType::Tuple2(a, b) | ZPtrType::Compact10(a, b)) => {
+                self.has_opaque_data(a) || self.has_opaque_data(b)
+            }
+            Some(ZPtrType::Compact110(a, b, c)) => {
+                self.has_opaque_data(a) || self.has_opaque_data(b) || self.has_opaque_data(c)
+            }
+        }
+    }
 }

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -305,7 +305,7 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 39] = [
     "fail",
 ];
 
-const META_SYMBOLS: [&str; 30] = [
+const META_SYMBOLS: [&str; 33] = [
     "def",
     "defrec",
     "load",
@@ -336,4 +336,7 @@ const META_SYMBOLS: [&str; 30] = [
     "defprotocol",
     "prove-protocol",
     "verify-protocol",
+    "micro-chain-serve",
+    "micro-chain-get",
+    "micro-chain-transition",
 ];


### PR DESCRIPTION
Implement the following meta commands:
* `micro-chain-serve` to start a chain server
* `micro-chain-get` for a client to get the current server state
* `micro-chain-transition` for a client to send a chain proof to the server

This is a minimal implementation for a demo and doesn't assume too much from the actual final micro-chain system, on which we will have more info later.