### PR TITLE
feat: `fail` built-in

### DIFF
--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -296,7 +296,7 @@ impl<F: Field> Op<F> {
                     .collect();
                 constrain_inequality_witness(sel.clone(), coeffs, diffs, builder);
             }
-            Op::AssertEq(a, b) => {
+            Op::AssertEq(a, b, _) => {
                 for (a, b) in a.iter().zip(b.iter()) {
                     let a = &map[*a];
                     let b = &map[*b];
@@ -407,7 +407,7 @@ impl<F: Field> Op<F> {
                     sel.clone(),
                 );
             }
-            Op::PreImg(idx, out) => {
+            Op::PreImg(idx, out, _) => {
                 let func = toplevel.get_by_index(*idx);
                 let mut inp = Vec::with_capacity(func.input_size);
                 for _ in 0..func.input_size {

--- a/src/lair/bytecode.rs
+++ b/src/lair/bytecode.rs
@@ -7,10 +7,13 @@
 use super::{map::Map, List, Name};
 
 /// The type for Lair operations
+#[allow(clippy::type_complexity)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Op<F> {
-    /// `AssertEq(x, y)` makes sure `x` is equal to `y`
-    AssertEq(List<usize>, List<usize>),
+    /// `AssertEq(x, y, fmt)` makes sure `x` is equal to `y`. If `fmt` is `Some`,
+    /// use it to format an error message and bail at runtime instead of panicking
+    /// when `x` is not equal to `y`
+    AssertEq(List<usize>, List<usize>, Option<fn(&[F], &[F]) -> String>),
     /// `AssertNe(x, y)` makes sure `x` is unequal to `y`
     AssertNe(List<usize>, List<usize>),
     /// `Contains(x, y)` makes sure an array `x` contains the value `y`
@@ -31,10 +34,12 @@ pub enum Op<F> {
     /// at index `i` in the toplevel when applied to the arguments at positions
     /// `[a, b, ...]` in the stack
     Call(usize, List<usize>),
-    /// `PreImg(i, [a, b, ...])` extends the stack with the latest preimage
+    /// `PreImg(i, [a, b, ...], fmt)` extends the stack with the latest preimage
     /// (beware of non-injectivity) of the function of index `i` when called with
-    /// arguments at positions `[a, b, ...]` in the stack
-    PreImg(usize, List<usize>),
+    /// arguments at positions `[a, b, ...]` in the stack. If `fmt` is `Some`,
+    /// use it to format an error message and bail at runtime instead of panicking
+    /// when the preimage is not available
+    PreImg(usize, List<usize>, Option<fn(&[F]) -> String>),
     /// `Store([y, ...])` pushes the pointer to `[y, ...]` to the stack
     Store(List<usize>),
     /// `Load(len, y)` extends the stack with the `len` values that is pointed by `y`

--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -42,10 +42,13 @@ impl<const N: usize> From<[Var; N]> for VarList {
 }
 
 /// Interface for basic Lair operations
+#[allow(clippy::type_complexity)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OpE<F> {
-    /// `AssertEq(x, y)` makes sure `x` is equal to `y`
-    AssertEq(Var, Var),
+    /// `AssertEq(x, y, fmt)` makes sure `x` is equal to `y`. If `fmt` is `Some`,
+    /// use it to format an error message and bail at runtime instead of panicking
+    /// when `x` is not equal to `y`
+    AssertEq(Var, Var, Option<fn(&[F], &[F]) -> String>),
     /// `AssertNe(x, y)` makes sure `x` is unequal to `y`
     AssertNe(Var, Var),
     /// `Contains(x, y)` makes sure an array `x` contains the value `y`
@@ -73,9 +76,11 @@ pub enum OpE<F> {
     /// `Call([x, ...], foo, [y, ...])` binds `x, ...` to the output of `foo`
     /// when applied to the arguments `y, ...`
     Call(VarList, Name, VarList),
-    /// `PreImg([x, ...], foo, [y, ...])` binds `x, ...` to the latest preimage
-    /// (beware of non-injectivity) of `foo` when called with arguments `y, ...`
-    PreImg(VarList, Name, VarList),
+    /// `PreImg([x, ...], foo, [y, ...], fmt)` binds `x, ...` to the latest preimage
+    /// (beware of non-injectivity) of `foo` when called with arguments `y, ...`.
+    /// If `fmt` is `Some`, use it to format an error message and bail at runtime
+    /// instead of panicking when the preimage is not available
+    PreImg(VarList, Name, VarList, Option<fn(&[F]) -> String>),
     /// `Store(x, [y, ...])` binds `x` to a pointer to `[y, ...]`
     Store(Var, VarList),
     /// `Load([x, ...], y)` binds `[x, ...]` to the values that is pointed by `y`

--- a/src/lair/macros.rs
+++ b/src/lair/macros.rs
@@ -79,7 +79,11 @@ macro_rules! block {
         $crate::block!({ $($tail)* }, $ops)
     }};
     ({ assert_eq!($a:ident, $b:ident); $($tail:tt)+ }, $ops:expr) => {{
-        $ops.push($crate::lair::expr::OpE::AssertEq($a, $b));
+        $ops.push($crate::lair::expr::OpE::AssertEq($a, $b, None));
+        $crate::block!({ $($tail)* }, $ops)
+    }};
+    ({ assert_eq!($a:ident, $b:ident, $fmt:expr); $($tail:tt)+ }, $ops:expr) => {{
+        $ops.push($crate::lair::expr::OpE::AssertEq($a, $b, Some($fmt)));
         $crate::block!({ $($tail)* }, $ops)
     }};
     ({ assert_ne!($a:ident, $b:ident); $($tail:tt)+ }, $ops:expr) => {{
@@ -214,7 +218,15 @@ macro_rules! block {
         let func = $crate::lair::Name(stringify!($func));
         let out = [$($crate::var!($tgt $(, $size)?)),*].into();
         let inp = [$($arg),*].into();
-        $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp));
+        $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp, None));
+        $(let $tgt = $crate::var!($tgt $(, $size)?);)*
+        $crate::block!({ $($tail)* }, $ops)
+    }};
+    ({ let ($($tgt:ident $(: [$size:expr])?),*) = preimg($func:ident, $($arg:ident),*, $fmt:expr); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($func));
+        let out = [$($crate::var!($tgt $(, $size)?)),*].into();
+        let inp = [$($arg),*].into();
+        $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp, Some($fmt)));
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
@@ -222,7 +234,7 @@ macro_rules! block {
         let func = $crate::lair::Name(stringify!($func));
         let out = [$crate::var!($tgt $(, $size)?)].into();
         let inp = [$($arg),*].into();
-        $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp));
+        $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp, None));
         let $tgt = $crate::var!($tgt $(, $size)?);
         $crate::block!({ $($tail)* }, $ops)
     }};

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -338,7 +338,7 @@ impl<F: PrimeField32> Op<F> {
                     push_depth(index, slice, ctx, result.depth);
                 }
             }
-            Op::PreImg(idx, out) => {
+            Op::PreImg(idx, out, _) => {
                 let func = ctx.toplevel.get_by_index(*idx);
                 let out = out.iter().map(|a| map[*a].0).collect::<List<_>>();
                 let inv_map = ctx.queries.inv_func_queries[*idx]

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -263,7 +263,7 @@ const USER_PACKAGE_NAME: &str = "lurk-user";
 
 pub(crate) const LURK_SYMBOLS: [&str; 2] = ["nil", "t"];
 
-pub(crate) const BUILTIN_SYMBOLS: [&str; 38] = [
+pub(crate) const BUILTIN_SYMBOLS: [&str; 39] = [
     "atom",
     "begin",
     "car",
@@ -302,6 +302,7 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 38] = [
     "<=",
     ">=",
     "breakpoint",
+    "fail",
 ];
 
 const META_SYMBOLS: [&str; 30] = [


### PR DESCRIPTION
* Generalize error message formatting in Lair's Preimg and AssertEq
* Remove the dependency on `lurk` from the `lair` module
  * The execution algorithm was calling a bigint formatting function
* Move Lurk specific message formatting to the reduction model
* Implement `fail` with a proper message for good user feedback