### PR TITLE
chore: enhance `ReservedTag::to_field`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arc-swap"
@@ -122,9 +122,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -318,9 +318,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -505,9 +505,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "expect-test"
@@ -1086,18 +1086,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
+checksum = "bae36f8710514b3e7aab028021733330de6e455e0352e19c6dd4513eecb7aa9a"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -1313,6 +1313,7 @@ dependencies = [
  "sha2",
  "sphinx-core",
  "sphinx-derive",
+ "strum",
  "thiserror",
  "vergen",
 ]
@@ -1906,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1919,15 +1920,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -2117,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags",
 ]
@@ -2211,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
@@ -2291,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.16"
+version = "2.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb7ac86243095b70a7920639507b71d51a63390d1ba26c4f60a552fbb914a37"
+checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
 dependencies = [
  "sdd",
 ]
@@ -2306,9 +2307,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
+checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
 
 [[package]]
 name = "sec1"
@@ -2332,18 +2333,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2352,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -2696,18 +2697,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2881,15 +2882,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
@@ -2904,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ rustyline-derive = "0.10"
 serde = "1.0"
 serde_json = "1.0"
 sha2 = "0.10.8"
+strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0.44"
 hybrid-array = "0.2.0-rc"
 lazy_static = "1.4.0"
@@ -106,6 +107,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 rayon = { workspace = true }
+strum = { workspace = true }
 itertools = { workspace = true }
 p3-air = { workspace = true }
 p3-baby-bear = { workspace = true }

--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -192,7 +192,7 @@ ledger2
 
 ;; Now we can open the committed ledger transfer function on a transaction.
 
-!(call #0x266ad08765995fadb14f1efa2ade34af5669ccbc0fc2426ab4847c099c36e5 '(1 0 2))
+!(call #0x9726fe649c4ca7efde87888798594e3c4f238ac1eca58e13f8c2f8b8b0793 '(1 0 2))
 
 ;; And the record reflects that Church sent one unit to Satoshi.
 
@@ -202,7 +202,7 @@ ledger2
 
 ;; We can verify the proof..
 
-!(verify "8bace909ec303b99d8355fc5308ae6967dbdf556a0d621c2cc853d436520a1")
+!(verify "40294916397e5ea423aa708c82bddfb49a33000fcd3b178e57d99c96797a40")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -219,24 +219,24 @@ ledger2
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(chain #0x85a7b9db0ace246928729f8559ec6732e39955797ca7b3684da5ca65d31bb1 '(1 0 2))
+!(chain #0x7a49523464e129d017831021202b79e32b2125a807219c0a81980504afb825 '(1 0 2))
 
 !(prove)
 
-!(verify "328001e09d7c13b746e2613197ef61181cf2dfff408ce83c06a9cd9d298851")
+!(verify "7569e1a5aed0ba2e1298c2379b156eceecf7ce8ece311d0bdee8dec030264e")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(chain #0x29bad6bf2c02a583336bb375d83bf8c320015dbeb4752956fe5234075dca68 '(5 0 2))
+!(chain #0xb70280e9be899a4940e4b6b5d69b56423b09d402e307e9a9714dbd4c6f8fe '(5 0 2))
 
 !(prove)
 
-!(verify "5ee44f52fcb62c88535775c4ee3b634a91a5c52be467f8d58bd6bebf837ad3")
+!(verify "4c943c0128ed71de52cc9631a90cdb2fcbde595992c3f6b69c4391855ea192")
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(chain #0x707aa8fdf6e887c1cc4f18ffe06aa2b3c175bb6d917fdb97b1eeb96f8e715d '(20 1 0))
+!(chain #0x5e7d7af3f1a4cffa54402b98f20e0caf420c32c85b07618dceaebfe989540b '(20 1 0))
 
 !(prove)
 
-!(verify "5e5dda667246d9426db1b221730bb648533823b24fb7dbf7bd71363d14100f")
+!(verify "7e465b97b59c3ab8ada3b203971b15a4dff812304c3533450ab25f6b01405e")

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -9,7 +9,7 @@
 
 ;; We chain a next commitment by applying the committed function to a value of 9.
 
-!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 9)
+!(chain #0x4b0eb13f048385909480e765f4eefec94c304edf9e01b2170869c9cdf8eb11 9)
 
 ;; The new counter value is 9, and the function returns a new functional commitment.
 
@@ -21,11 +21,11 @@
 
 ;; We can verify the proof.
 
-!(verify "68bf8123715dcc0e230971dbff2edc365f5e0e1ec82518cda637b3ac49a4ab")
+!(verify "2609e61d828611427781388bb243edff2d5837762605a576517ca8bdb80729")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(chain #0x7ef60daca90d37a29e5bb066615f925148f07ced803855f41907e7ace3d066 12)
+!(chain #0x82bfc47b9b430f5b2122157cb2ffc23514608aed3fdcad4280137b20b47893 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 
@@ -35,11 +35,11 @@
 
 ;; And verify.
 
-!(verify "13b40e5aac59c950f2be0092c4c4f745be4c526711912933b8b3a466107cbb")
+!(verify "23febcbd5eed7e04a1733364e319e7c99415ca8a556f5fb6376662f732979b")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
-!(chain #0x7edc8f2fc3ddab594374d9e4344c7160f65b77b0e4f9da7292c63faa667fc7 14)
+!(chain #0x7992fc230601060378202010780dc88d00321372cec452876d370f73fb3b84 14)
 
 ;; 21 + 14 = 35, as expected.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "778deec686e6e2db8247630ca76c30665a44a5082f15d63a7737af83de1a46")
+!(verify "5438ff9d40034f5e047d91fbe67ee56f13d26641b619e5e945595c954b7b2f")
 
 ;; Repeat indefinitely.
 

--- a/demo/functional-commitment.lurk
+++ b/demo/functional-commitment.lurk
@@ -10,7 +10,7 @@
 
 ;; We open the functional commitment on input 5: Evaluate f(5).
 
-!(call #0x584d533ca5f821e177459c56090fba62296b44f1cc289510332996224ac2ce 5)
+!(call #0x1aabc88a967eb6c0ab3e73eb5a9cb55380cdcfc8aaf6a488a4620bf67afb4b 5)
 
 ;; We can prove the functional-commitment opening.
 
@@ -18,8 +18,8 @@
 
 ;; We can inspect the input/output expressions of the proof.
 
-!(inspect "96aed5bd2fcfe3cd8ba52b6d0361b9af6fddc7a24729de7b9a9b1507802298")
+!(inspect "b68e59e1a971a9b02f79cb5073d7ff6b236f685f25ad3cc44890941e521d1")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(verify "96aed5bd2fcfe3cd8ba52b6d0361b9af6fddc7a24729de7b9a9b1507802298")
+!(verify "b68e59e1a971a9b02f79cb5073d7ff6b236f685f25ad3cc44890941e521d1")

--- a/demo/protocol.lurk
+++ b/demo/protocol.lurk
@@ -10,13 +10,13 @@
   :description "hash opens to a pair (a, b) s.t. a+b=30 and a>10")
 
 ;; This is the prover's pair, whose hash is
-;; #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc
+;; #c0x76c3537770d61633a76264596e9fdefcf3bca72ade7f9553d5b3e6bfacba3b
 (commit '(13 . 17))
 
 ;; Let's prove it and write the proof to the file protocol-proof
 !(prove-protocol my-protocol
   "protocol-proof"
-  #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc
+  #c0x76c3537770d61633a76264596e9fdefcf3bca72ade7f9553d5b3e6bfacba3b
   '(13 . 17))
 
 ;; Now it can be verified

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -71,8 +71,8 @@
 !(assert-eq '(1 4 9 16) (map (lambda (x) (* x x)) '(1 2 3 4)))
 
 ;; permute
-!(assert-eq '(c b a d e) (permute '(a b c d e) 123))
-!(assert-eq '(b c d a e) (permute '(a b c d e) 987))
+!(assert-eq '(e c a b d) (permute '(a b c d e) 123))
+!(assert-eq '(a d c b e) (permute '(a b c d e) 987))
 
 ;; expt
 !(assert-eq 32 (expt 2 5))

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -1,9 +1,8 @@
 use anyhow::{bail, Result};
 use hashbrown::HashMap;
-use indexmap::IndexMap;
 use itertools::Itertools;
 use p3_field::{AbstractField, PrimeField32};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 use sphinx_core::stark::{Indexed, MachineRecord};
 use std::ops::Range;
 
@@ -17,10 +16,8 @@ use super::{
     bytecode::{Ctrl, Func, Op},
     chipset::Chipset,
     toplevel::Toplevel,
-    List,
+    FxIndexMap, List,
 };
-
-type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 type QueryMap<F> = FxIndexMap<List<F>, QueryResult<F>>;
 type InvQueryMap<F> = FxHashMap<List<F>, List<F>>;

--- a/src/lair/mod.rs
+++ b/src/lair/mod.rs
@@ -1,4 +1,6 @@
+use indexmap::IndexMap;
 use p3_field::Field;
+use rustc_hash::FxBuildHasher;
 
 use crate::func;
 
@@ -44,6 +46,8 @@ pub(crate) fn field_from_u32<F: p3_field::AbstractField>(i: u32) -> F {
 }
 
 pub type List<T> = Box<[T]>;
+
+pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 #[allow(dead_code)]
 pub(crate) fn demo_toplevel<F: Field + Ord>() -> Toplevel<F, Nochip> {

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -5,6 +5,7 @@
 use num_traits::FromPrimitive;
 use p3_baby_bear::BabyBear;
 use rustc_hash::FxHashMap;
+use strum::EnumCount;
 
 use crate::loam::allocation::Allocator;
 use crate::loam::lurk_sym_index;
@@ -189,9 +190,9 @@ impl Tag {
     }
 
     pub fn wide_relation() -> Vec<(LE, Wide)> {
-        (0..Self::count())
+        (0..Self::COUNT)
             .map(|i| {
-                let tag = Tag::from_u32(i as u32 + 2).unwrap();
+                let tag = Tag::from_u32(i as u32).unwrap();
                 (tag.elt(), tag.value())
             })
             .collect()

--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -328,10 +328,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
             "The secret is the reduction of <secret_expr>, which must be a",
             "bignum, and the payload is the reduction of <payload_expr>.",
         ],
-        example: &[
-            "!(hide (bignum (commit 123)) 42)",
-            "!(hide #0x4a902d7be96d1021a473353bd59247ea4c0f0688b5bae0c833a1f624b77ede 42)",
-        ],
+        example: &["!(hide (bignum (commit 123)) 42)", "!(hide #0x123 42)"],
         run: |repl, args, _path| {
             let (&secret_expr, &payload_expr) = repl.peek2(args)?;
             let (secret, _) = repl.reduce_aux(&secret_expr)?;
@@ -388,7 +385,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         info: &[],
         example: &[
             "!(commit 123)",
-            "!(open #0x4a902d7be96d1021a473353bd59247ea4c0f0688b5bae0c833a1f624b77ede)",
+            "!(open #c0x944834111822843979ace19833d05ca9daf2f655230faec517433e72fe777b)",
         ],
         run: |repl, args, _path| {
             let expr = *repl.peek1(args)?;
@@ -407,7 +404,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         info: &[],
         example: &[
             "!(commit 123)",
-            "!(fetch #0x4a902d7be96d1021a473353bd59247ea4c0f0688b5bae0c833a1f624b77ede)",
+            "!(fetch #c0x944834111822843979ace19833d05ca9daf2f655230faec517433e72fe777b)",
         ],
         run: |repl, args, _path| {
             let expr = *repl.peek1(args)?;
@@ -444,7 +441,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
         info: &["It's also capable of opening persisted commitments."],
         example: &[
             "(commit (lambda (x) x))",
-            "!(call #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 0)",
+            "!(call #c0x361877c9845ddda6aa16dd6c6bcd26fcea7b93930106a19f5d7d5cf10a9015 0)",
         ],
         run: |repl, args, _path| {
             Self::call(repl, args)?;
@@ -483,7 +480,7 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
                        (let ((counter (+ counter x)))
                          (cons counter (commit (add counter)))))))
                (add 0)))",
-            "!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 1)",
+            "!(chain #c0x4b0eb13f048385909480e765f4eefec94c304edf9e01b2170869c9cdf8eb11 1)",
         ],
         run: |repl, args, _path| {
             let cons = Self::call(repl, args)?;
@@ -936,7 +933,7 @@ impl<H: Chipset<F>> MetaCmd<F, H> {
             "(commit '(13 . 17))",
             "!(prove-protocol my-protocol",
             "  \"protocol-proof\"",
-            "  #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc",
+            "  #c0x76c3537770d61633a76264596e9fdefcf3bca72ade7f9553d5b3e6bfacba3b",
             "  '(13 . 17))",
         ],
         run: |repl, args, _path| {

--- a/src/lurk/cli/tests/first.lurk
+++ b/src/lurk/cli/tests/first.lurk
@@ -35,17 +35,17 @@
 ;; test calling functional commitments
 !(call (lambda (x) x) 0)
 !(commit (eval '(lambda (x) x)))
-!(call #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 0)
-!(call (comm #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc) 0)
+!(call #0x361877c9845ddda6aa16dd6c6bcd26fcea7b93930106a19f5d7d5cf10a9015 0)
+!(call (comm #0x361877c9845ddda6aa16dd6c6bcd26fcea7b93930106a19f5d7d5cf10a9015) 0)
 
 ;; test chain and transition
 !(commit (eval '(letrec ((add (lambda (counter x)
                        (let ((counter (+ counter x)))
                          (cons counter (commit (add counter)))))))
                (add 0))))
-!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 1)
+!(chain #c0x4b0eb13f048385909480e765f4eefec94c304edf9e01b2170869c9cdf8eb11 1)
 
-!(def state0 (cons nil (comm #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d)))
+!(def state0 (cons nil (comm #0x4b0eb13f048385909480e765f4eefec94c304edf9e01b2170869c9cdf8eb11)))
 !(transition state1 state0 1)
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))
@@ -59,7 +59,7 @@
                          (cons counter (bignum (commit (add counter))))))))
                (add 0))))
 
-!(def state0 (cons nil #0x3782a9f09a9311ba5f9d41718c470ca6e83a1701cb00a90cd0a590b94f3da3))
+!(def state0 (cons nil #0xc03134a4f3ca679c48553a312d455477dffc16589641d33e0676bf1f86e69))
 !(transition state1 state0 1)
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))

--- a/src/lurk/cli/tests/prove.lurk
+++ b/src/lurk/cli/tests/prove.lurk
@@ -1,5 +1,5 @@
 !(prove (cons 1 2))
-!(verify "4668bed30416bfbdbb8011df22ff919ececd2607357b77638a1131b395dc23")
+!(verify "1fe27d9ba542dbf6a82300a7ff3eb19c95c56eec112e095c16cec73d85c576")
 
 !(defprotocol my-protocol (hash pair)
   (cons
@@ -13,7 +13,7 @@
 
 !(prove-protocol my-protocol
   "repl-test-protocol-proof"
-  #0x818e61a96cb66761e3a7a338bfd7e374fade81e70455ad6b63e63438823bbc
+  #c0x76c3537770d61633a76264596e9fdefcf3bca72ade7f9553d5b3e6bfacba3b
   '(13 . 17))
 
 !(verify-protocol my-protocol "repl-test-protocol-proof")

--- a/src/lurk/cli/tests/second.lurk
+++ b/src/lurk/cli/tests/second.lurk
@@ -1,17 +1,17 @@
 ;; test fetching data from first.lurk
-!(fetch #0x77096cf6a7692e3c7e0ddb3bb6e82cf1c2d00d0984be91ce453c91b60b1bcb)
-!(assert-eq (open #0x77096cf6a7692e3c7e0ddb3bb6e82cf1c2d00d0984be91ce453c91b60b1bcb) 42)
+!(fetch #0x22b5fa9cf049349a7d0e5fdeef38e865b79e13a9feb29730c845973af08bef)
+!(assert-eq (open #0x22b5fa9cf049349a7d0e5fdeef38e865b79e13a9feb29730c845973af08bef) 42)
 
 ;; test open
-!(open #0x4be65b0be0e53c98cbde4451413f4205573b7cbf51b1778500759407e2cd88)
-!(assert-eq (open #0x4be65b0be0e53c98cbde4451413f4205573b7cbf51b1778500759407e2cd88) 42)
+!(open #0x91542a0e943be900a067ecd113d8b3340e0aed1c3c00eb06768a318c17a885)
+!(assert-eq (open #0x91542a0e943be900a067ecd113d8b3340e0aed1c3c00eb06768a318c17a885) 42)
 
 ;; test call/chain
-!(call #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 0)
-!(chain #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d 1)
+!(call #0x361877c9845ddda6aa16dd6c6bcd26fcea7b93930106a19f5d7d5cf10a9015 0)
+!(chain #0x4b0eb13f048385909480e765f4eefec94c304edf9e01b2170869c9cdf8eb11 1)
 
 ;; test transition
-!(def state (cons nil #0x5a34ed7712c5fd2f324feb0e1764b27bac9259c4b663e4601e678939a9363d))
+!(def state (cons nil #0x4b0eb13f048385909480e765f4eefec94c304edf9e01b2170869c9cdf8eb11))
 !(transition state1 state 1)
 !(assert-eq (car state1) 1)
 

--- a/src/lurk/cli/tests/verify.lurk
+++ b/src/lurk/cli/tests/verify.lurk
@@ -1,5 +1,5 @@
-!(inspect "4668bed30416bfbdbb8011df22ff919ececd2607357b77638a1131b395dc23")
-!(verify "4668bed30416bfbdbb8011df22ff919ececd2607357b77638a1131b395dc23")
+!(inspect "1fe27d9ba542dbf6a82300a7ff3eb19c95c56eec112e095c16cec73d85c576")
+!(verify "1fe27d9ba542dbf6a82300a7ff3eb19c95c56eec112e095c16cec73d85c576")
 
 !(load-expr my-protocol "repl-test-protocol")
 !(verify-protocol my-protocol "repl-test-protocol-proof")

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -415,7 +415,7 @@ test!(test_hide2, "(hide (commit 321) 123)", |_| ZPtr::err(
 test!(test_open_roundtrip, "(open (commit 123))", |_| uint(123));
 test!(
     test_open_raw_roundtrip,
-    "(begin (commit 123n) (open #0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882))",
+    "(begin (commit 123n) (open #c0xaa8db8504fa55b480f3da7a75f3480174f28d683f4c3ac451b7cee488d2fe))",
     |_| ZPtr::num(F::from_canonical_u32(123))
 );
 test!(test_secret, "(secret (commit 123))", |_| ZPtr::big_num(
@@ -423,12 +423,12 @@ test!(test_secret, "(secret (commit 123))", |_| ZPtr::big_num(
 ));
 test!(
     test_func_big_num_app,
-    "(begin (commit (lambda (x) x)) (#0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc 42))",
+    "(begin (commit (lambda (x) x)) (#0x361877c9845ddda6aa16dd6c6bcd26fcea7b93930106a19f5d7d5cf10a9015 42))",
     |_| uint(42)
 );
 test!(
     test_func_comm_app,
-    "(begin (commit (lambda (x) x)) ((comm #0x83420bafb3cb56870b10b498607c0a6314b0ea331328bbb232c74078abb5dc) 42))",
+    "(begin (commit (lambda (x) x)) ((comm #0x361877c9845ddda6aa16dd6c6bcd26fcea7b93930106a19f5d7d5cf10a9015) 42))",
     |_| uint(42)
 );
 
@@ -437,7 +437,7 @@ test!(test_raw_big_num, "#0x0", |_| ZPtr::big_num([F::zero(); 8]));
 test!(test_raw_comm, "#c0x0", |_| ZPtr::comm([F::zero(); 8]));
 test!(
     test_raw_big_num2,
-    "#0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882",
+    "#0xaa8db8504fa55b480f3da7a75f3480174f28d683f4c3ac451b7cee488d2fe",
     |_| {
         let mut preimg = Vec::with_capacity(24);
         preimg.extend([F::zero(); 8]);
@@ -447,7 +447,7 @@ test!(
 );
 test!(
     test_raw_comm2,
-    "#c0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882",
+    "#c0xaa8db8504fa55b480f3da7a75f3480174f28d683f4c3ac451b7cee488d2fe",
     |_| {
         let mut preimg = Vec::with_capacity(24);
         preimg.extend([F::zero(); 8]);

--- a/src/lurk/tag.rs
+++ b/src/lurk/tag.rs
@@ -2,13 +2,26 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use p3_field::{AbstractField, PrimeField32};
 use serde::{Deserialize, Serialize};
+use strum::{EnumCount, EnumIter};
 
 #[repr(u32)]
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, FromPrimitive,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    FromPrimitive,
+    EnumCount,
+    EnumIter,
 )]
 pub enum Tag {
-    U64 = 2, // 0 and 1 are reserved for nil and t inside the vm
+    U64 = 0,
     Num,
     BigNum,
     Comm,
@@ -34,10 +47,6 @@ impl Tag {
     pub fn from_field<F: PrimeField32>(f: &F) -> Tag {
         Tag::from_u32(f.as_canonical_u32()).expect("Field element doesn't map to a Tag")
     }
-
-    pub fn count() -> usize {
-        14
-    }
 }
 
 impl From<Tag> for i32 {
@@ -52,25 +61,17 @@ mod test {
     use num_traits::FromPrimitive;
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeField32;
+    use strum::{EnumCount, IntoEnumIterator};
+
+    #[test]
+    fn test_strum() {
+        assert_eq!(14, Tag::COUNT);
+        assert_eq!(Tag::COUNT, Tag::iter().count());
+    }
 
     #[test]
     fn test_tag_index_roundtrip() {
-        for tag in [
-            Tag::Cons,
-            Tag::Sym,
-            Tag::Fun,
-            Tag::Num,
-            Tag::Str,
-            Tag::Char,
-            Tag::Comm,
-            Tag::U64,
-            Tag::Key,
-            Tag::Env,
-            Tag::Err,
-            Tag::Thunk,
-            Tag::Builtin,
-            Tag::BigNum,
-        ] {
+        for tag in Tag::iter() {
             let f = tag.to_field::<BabyBear>();
             let u = f.as_canonical_u32();
             assert_eq!(Some(tag), Tag::from_u32(u));

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -1076,11 +1076,11 @@ mod test {
         let digest = lurk_hasher().hash(&preimg).try_into().unwrap();
         assert_eq!(
             zstore.fmt_with_state(state, &ZPtr::big_num(digest)),
-            "#0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882"
+            "#0xaa8db8504fa55b480f3da7a75f3480174f28d683f4c3ac451b7cee488d2fe"
         );
         assert_eq!(
             zstore.fmt_with_state(state, &ZPtr::comm(digest)),
-            "#c0x20a6e497cdc1145d6684f0d31474f160ddf2832673d1d57885a5f28a732882"
+            "#c0xaa8db8504fa55b480f3da7a75f3480174f28d683f4c3ac451b7cee488d2fe"
         );
 
         let empty_str = zstore.intern_string("");


### PR DESCRIPTION
Make it so that `Tag::to_field` doesn't need to skip reserved tags by pushing reserved tags to start from where tags end.