### PR TITLE
feat: `Lang` and custom gadgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,9 +1245,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -1273,6 +1273,7 @@ dependencies = [
  "camino",
  "clap",
  "criterion",
+ "either",
  "expect-test",
  "hashbrown 0.14.5",
  "home",
@@ -2118,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "62871f2d65009c0256aed1b9cfeeb8ac272833c404e13d53d400cd0dad7a2ac0"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bincode = "1"
 camino = "1.1"
 clap = "4.5.15"
 criterion = "0.5"
+either = "1"
 expect-test = "1.4.1"
 home = "0.5"
 indexmap = "2.2.6"
@@ -84,6 +85,7 @@ bincode = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 expect-test = { workspace = true }
+either = { workspace = true }
 home = { workspace = true }
 hybrid-array = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use loam::{
     lair::{
-        chipset::Chipset,
+        chipset::{Chipset, NoChip},
         execute::{QueryRecord, Shard},
         func_chip::FuncChip,
         lair_chip::{build_chip_vector, build_lair_chip_vector, LairMachineProgram},
@@ -19,7 +19,7 @@ use loam::{
         List,
     },
     lurk::{
-        eval::build_lurk_toplevel,
+        eval::build_lurk_toplevel_native,
         zstore::{lurk_zstore, ZPtr},
     },
 };
@@ -46,18 +46,18 @@ fn build_lurk_expr(a: &str, b: &str) -> String {
     )
 }
 
-fn setup<'a, H: Chipset<BabyBear>>(
+fn setup<'a, C: Chipset<BabyBear>>(
     a: &'a str,
     b: &'a str,
-    toplevel: &'a Toplevel<BabyBear, H>,
+    toplevel: &'a Toplevel<BabyBear, C, NoChip>,
 ) -> (
     List<BabyBear>,
-    FuncChip<'a, BabyBear, H>,
+    FuncChip<'a, BabyBear, C, NoChip>,
     QueryRecord<BabyBear>,
 ) {
     let code = build_lurk_expr(a, b);
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag, digest } = zstore.read(&code).unwrap();
+    let ZPtr { tag, digest } = zstore.read(&code, &Default::default()).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
     record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
@@ -75,7 +75,7 @@ fn setup<'a, H: Chipset<BabyBear>>(
 fn evaluation(c: &mut Criterion) {
     let args = get_lcs_args();
     c.bench_function("lcs-evaluation", |b| {
-        let (toplevel, _) = build_lurk_toplevel();
+        let (toplevel, ..) = build_lurk_toplevel_native();
         let (args, lurk_main, record) = setup(args.0, args.1, &toplevel);
         b.iter_batched(
             || (args.clone(), record.clone()),
@@ -92,7 +92,7 @@ fn evaluation(c: &mut Criterion) {
 fn trace_generation(c: &mut Criterion) {
     let args = get_lcs_args();
     c.bench_function("lcs-trace-generation", |b| {
-        let (toplevel, _) = build_lurk_toplevel();
+        let (toplevel, ..) = build_lurk_toplevel_native();
         let (args, lurk_main, mut record) = setup(args.0, args.1, &toplevel);
         toplevel
             .execute(lurk_main.func(), &args, &mut record, None)
@@ -110,7 +110,7 @@ fn trace_generation(c: &mut Criterion) {
 fn e2e(c: &mut Criterion) {
     let args = get_lcs_args();
     c.bench_function("lcs-e2e", |b| {
-        let (toplevel, _) = build_lurk_toplevel();
+        let (toplevel, ..) = build_lurk_toplevel_native();
         let (args, lurk_main, record) = setup(args.0, args.1, &toplevel);
 
         b.iter_batched(

--- a/benches/lurk.rs
+++ b/benches/lurk.rs
@@ -1,12 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::time::Duration;
 
-use loam::lurk::eval::build_lurk_toplevel;
+use loam::lurk::eval::build_lurk_toplevel_native;
 
 fn toplevel(c: &mut Criterion) {
     c.bench_function("toplevel", |b| {
         b.iter(|| {
-            build_lurk_toplevel();
+            build_lurk_toplevel_native();
         })
     });
 }

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use loam::{
     lair::{
-        chipset::Chipset,
+        chipset::{Chipset, NoChip},
         execute::{QueryRecord, Shard},
         func_chip::FuncChip,
         lair_chip::{build_chip_vector, build_lair_chip_vector, LairMachineProgram},
@@ -19,7 +19,7 @@ use loam::{
         List,
     },
     lurk::{
-        eval::build_lurk_toplevel,
+        eval::build_lurk_toplevel_native,
         zstore::{lurk_zstore, ZPtr},
     },
 };
@@ -47,18 +47,18 @@ fn build_lurk_expr(n: usize) -> String {
     )
 }
 
-fn setup<H: Chipset<BabyBear>>(
+fn setup<C: Chipset<BabyBear>>(
     n: usize,
-    toplevel: &Toplevel<BabyBear, H>,
+    toplevel: &Toplevel<BabyBear, C, NoChip>,
 ) -> (
     List<BabyBear>,
-    FuncChip<'_, BabyBear, H>,
+    FuncChip<'_, BabyBear, C, NoChip>,
     QueryRecord<BabyBear>,
 ) {
     let code = build_lurk_expr(n);
 
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag, digest } = zstore.read(&code).unwrap();
+    let ZPtr { tag, digest } = zstore.read(&code, &Default::default()).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
     record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);
@@ -76,7 +76,7 @@ fn setup<H: Chipset<BabyBear>>(
 fn evaluation(c: &mut Criterion) {
     let arg = get_sum_arg();
     c.bench_function(&format!("sum-evaluation-{arg}"), |b| {
-        let (toplevel, _) = build_lurk_toplevel();
+        let (toplevel, ..) = build_lurk_toplevel_native();
         let (args, lurk_main, record) = setup(arg, &toplevel);
         b.iter_batched(
             || (args.clone(), record.clone()),
@@ -93,7 +93,7 @@ fn evaluation(c: &mut Criterion) {
 fn trace_generation(c: &mut Criterion) {
     let arg = get_sum_arg();
     c.bench_function(&format!("sum-trace-generation-{arg}"), |b| {
-        let (toplevel, _) = build_lurk_toplevel();
+        let (toplevel, ..) = build_lurk_toplevel_native();
         let (args, lurk_main, mut record) = setup(arg, &toplevel);
         toplevel
             .execute(lurk_main.func(), &args, &mut record, None)
@@ -111,7 +111,7 @@ fn trace_generation(c: &mut Criterion) {
 fn e2e(c: &mut Criterion) {
     let arg = get_sum_arg();
     c.bench_function(&format!("sum-e2e-{arg}"), |b| {
-        let (toplevel, _) = build_lurk_toplevel();
+        let (toplevel, ..) = build_lurk_toplevel_native();
         let (args, lurk_main, record) = setup(arg, &toplevel);
 
         b.iter_batched(

--- a/demo/mastermind.lurk
+++ b/demo/mastermind.lurk
@@ -5,7 +5,7 @@
 ;; Tries to remove the first instance of elt from list and returns (removed? . remaining).
 ;; removed? is true if elt was removed.
 ;; remaining is a list of the remaining elements (in reverse order) whether or not elt was removed.
-;; If elt occurs one than once in list, only the first occurence is removed.
+;; If elt occurs one than once in list, only the first occurrence is removed.
 !(def maybe-remove (lambda (elt list)
                      (letrec ((aux (lambda (removed? acc elt list)
                                      (if list

--- a/src/air/debug.rs
+++ b/src/air/debug.rs
@@ -116,9 +116,13 @@ impl<F: PrimeField32> TraceQueries<F> {
 }
 
 /// Helper function to execute and test queries and constraints using `debug_constraints_collecting_queries`
-pub fn debug_chip_constraints_and_queries_with_sharding<F: PrimeField32, C: Chipset<F>>(
+pub fn debug_chip_constraints_and_queries_with_sharding<
+    F: PrimeField32,
+    C1: Chipset<F>,
+    C2: Chipset<F>,
+>(
     record: &QueryRecord<F>,
-    chips: &[LairChip<'_, F, C>],
+    chips: &[LairChip<'_, F, C1, C2>],
     config: Option<ShardingConfig>,
 ) {
     let full_shard = Shard::new(record);

--- a/src/lair/bytecode.rs
+++ b/src/lair/bytecode.rs
@@ -81,7 +81,7 @@ pub enum Ctrl<F> {
     Return(usize, List<usize>),
 }
 
-/// Represents the cases for `Ctrl::Match`, containing the branches for successfull
+/// Represents the cases for `Ctrl::Match`, containing the branches for successful
 /// matches and an optional default case in case there's no match. Each code path
 /// is encoded as its own block
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -148,8 +148,8 @@ pub struct Func<F> {
 impl<F> Func<F> {
     /// Getter for the name
     #[inline]
-    pub fn name(&self) -> Name {
-        self.name
+    pub fn name(&self) -> &Name {
+        &self.name
     }
 
     /// Getter for the body block

--- a/src/lair/chipset.rs
+++ b/src/lair/chipset.rs
@@ -1,3 +1,4 @@
+use either::Either;
 use p3_air::AirBuilder;
 use p3_field::PrimeField32;
 
@@ -45,9 +46,85 @@ pub trait Chipset<F>: Sync {
     ) -> Vec<AB::Expr>;
 }
 
-pub struct Nochip;
+impl<F, C1: Chipset<F>, C2: Chipset<F>> Chipset<F> for &Either<C1, C2> {
+    fn input_size(&self) -> usize {
+        match self {
+            Either::Left(c) => c.input_size(),
+            Either::Right(c) => c.input_size(),
+        }
+    }
 
-impl<F> Chipset<F> for Nochip {
+    fn output_size(&self) -> usize {
+        match self {
+            Either::Left(c) => c.output_size(),
+            Either::Right(c) => c.output_size(),
+        }
+    }
+
+    fn execute(
+        &self,
+        input: &[F],
+        nonce: u32,
+        queries: &mut QueryRecord<F>,
+        requires: &mut Vec<Record>,
+    ) -> Vec<F>
+    where
+        F: PrimeField32,
+    {
+        match self {
+            Either::Left(c) => c.execute(input, nonce, queries, requires),
+            Either::Right(c) => c.execute(input, nonce, queries, requires),
+        }
+    }
+
+    fn execute_simple(&self, input: &[F]) -> Vec<F> {
+        match self {
+            Either::Left(c) => c.execute_simple(input),
+            Either::Right(c) => c.execute_simple(input),
+        }
+    }
+
+    fn witness_size(&self) -> usize {
+        match self {
+            Either::Left(c) => c.witness_size(),
+            Either::Right(c) => c.witness_size(),
+        }
+    }
+
+    fn require_size(&self) -> usize {
+        match self {
+            Either::Left(c) => c.require_size(),
+            Either::Right(c) => c.require_size(),
+        }
+    }
+
+    fn populate_witness(&self, input: &[F], witness: &mut [F]) -> Vec<F> {
+        match self {
+            Either::Left(c) => c.populate_witness(input, witness),
+            Either::Right(c) => c.populate_witness(input, witness),
+        }
+    }
+
+    fn eval<AB: AirBuilder<F = F> + LookupBuilder>(
+        &self,
+        builder: &mut AB,
+        is_real: AB::Expr,
+        input: Vec<AB::Expr>,
+        witness: &[AB::Var],
+        nonce: AB::Expr,
+        requires: &[RequireRecord<AB::Var>],
+    ) -> Vec<AB::Expr> {
+        match self {
+            Either::Left(c) => c.eval(builder, is_real, input, witness, nonce, requires),
+            Either::Right(c) => c.eval(builder, is_real, input, witness, nonce, requires),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct NoChip;
+
+impl<F> Chipset<F> for NoChip {
     fn input_size(&self) -> usize {
         unimplemented!()
     }

--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -9,6 +9,12 @@ pub struct Var {
     pub size: usize,
 }
 
+impl Var {
+    pub fn atom(name: &'static str) -> Self {
+        Self { name, size: 1 }
+    }
+}
+
 impl std::fmt::Display for Var {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.name)
@@ -37,6 +43,12 @@ impl VarList {
 
 impl<const N: usize> From<[Var; N]> for VarList {
     fn from(value: [Var; N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Vec<Var>> for VarList {
+    fn from(value: Vec<Var>) -> Self {
         Self(value.into())
     }
 }
@@ -109,6 +121,16 @@ pub struct BlockE<F> {
     pub ctrl: CtrlE<F>,
 }
 
+impl<F> BlockE<F> {
+    #[inline]
+    pub fn no_op(ctrl: CtrlE<F>) -> Self {
+        Self {
+            ops: [].into(),
+            ctrl,
+        }
+    }
+}
+
 /// Encodes the logical flow of a Lair program
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CtrlE<F> {
@@ -124,13 +146,30 @@ pub enum CtrlE<F> {
     Return(VarList),
 }
 
-/// Represents the cases for `CtrlE::Match`, containing the branches for successfull
+impl<F> CtrlE<F> {
+    #[inline]
+    pub fn return_vars<const N: usize>(vars: [Var; N]) -> Self {
+        Self::Return(vars.into())
+    }
+}
+
+/// Represents the cases for `CtrlE::Match`, containing the branches for successful
 /// matches and an optional default case in case there's no match. Each code path
 /// is encoded as its own block
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CasesE<K, F> {
     pub branches: Vec<(K, BlockE<F>)>,
     pub default: Option<Box<BlockE<F>>>,
+}
+
+impl<K, F> CasesE<K, F> {
+    #[inline]
+    pub fn no_default(branches: Vec<(K, BlockE<F>)>) -> Self {
+        Self {
+            branches,
+            default: None,
+        }
+    }
 }
 
 /// Abstraction for a Lair function, which has a name, the input variables, the

--- a/src/lair/macros.rs
+++ b/src/lair/macros.rs
@@ -177,32 +177,32 @@ macro_rules! block {
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let ($($tgt:ident $(: [$size:expr])?),*) = call($func:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let ($($tgt:ident $(: [$size:expr])?),*) = call($name:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$($crate::var!($tgt $(, $size)?)),*].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::Call(out, func, inp));
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let $tgt:ident $(: [$size:expr])? = call($func:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let $tgt:ident $(: [$size:expr])? = call($name:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$crate::var!($tgt $(, $size)?)].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::Call(out, func, inp));
         let $tgt = $crate::var!($tgt $(, $size)?);
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let ($($tgt:ident $(: [$size:expr])?),*) = extern_call($func:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let ($($tgt:ident $(: [$size:expr])?),*) = extern_call($name:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$($crate::var!($tgt $(, $size)?)),*].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::ExternCall(out, func, inp));
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let $tgt:ident $(: [$size:expr])? = extern_call($func:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let $tgt:ident $(: [$size:expr])? = extern_call($name:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$crate::var!($tgt $(, $size)?)].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::ExternCall(out, func, inp));
@@ -214,24 +214,24 @@ macro_rules! block {
         $ops.push($crate::lair::expr::OpE::Emit(inp));
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let ($($tgt:ident $(: [$size:expr])?),*) = preimg($func:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let ($($tgt:ident $(: [$size:expr])?),*) = preimg($name:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$($crate::var!($tgt $(, $size)?)),*].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp, None));
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let ($($tgt:ident $(: [$size:expr])?),*) = preimg($func:ident, $($arg:ident),*, $fmt:expr); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let ($($tgt:ident $(: [$size:expr])?),*) = preimg($name:ident, $($arg:ident),*, $fmt:expr); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$($crate::var!($tgt $(, $size)?)),*].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp, Some($fmt)));
         $(let $tgt = $crate::var!($tgt $(, $size)?);)*
         $crate::block!({ $($tail)* }, $ops)
     }};
-    ({ let $tgt:ident $(: [$size:expr])? = preimg($func:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
-        let func = $crate::lair::Name(stringify!($func));
+    ({ let $tgt:ident $(: [$size:expr])? = preimg($name:ident, $($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let func = $crate::lair::Name(stringify!($name));
         let out = [$crate::var!($tgt $(, $size)?)].into();
         let inp = [$($arg),*].into();
         $ops.push($crate::lair::expr::OpE::PreImg(out, func, inp, None));

--- a/src/lair/map.rs
+++ b/src/lair/map.rs
@@ -46,17 +46,6 @@ impl<K: Ord, V> Map<K, V> {
 }
 
 impl<K, V> Map<K, V> {
-    /// Creates a `Map` from a vector without sorting
-    ///
-    /// # Warning
-    /// It will create an inconsistent map if the pairs aren't already sorted
-    #[inline]
-    pub(crate) fn from_vec_unsafe(pairs: Vec<(K, V)>) -> Self {
-        Self(pairs.into())
-    }
-}
-
-impl<K, V> Map<K, V> {
     /// Returns the slice of pairs
     #[inline]
     pub fn get_pairs(&self) -> &[(K, V)] {

--- a/src/lair/memory.rs
+++ b/src/lair/memory.rs
@@ -121,7 +121,7 @@ mod tests {
     use crate::lair::execute::QueryRecord;
     use crate::{
         func,
-        lair::{chipset::Nochip, func_chip::FuncChip, toplevel::Toplevel},
+        lair::{chipset::NoChip, func_chip::FuncChip, toplevel::Toplevel},
     };
     use p3_baby_bear::BabyBear as F;
     use p3_field::AbstractField;
@@ -139,7 +139,7 @@ mod tests {
             let (_x, y, _z) = load(ptr1);
             return (ptr2, y)
         });
-        let toplevel = Toplevel::<F, Nochip>::new_pure(&[func_e]);
+        let toplevel = Toplevel::<F, NoChip, NoChip>::new_pure(&[func_e]);
         let test_chip = FuncChip::from_name("test", &toplevel);
         let mut queries = QueryRecord::new(&toplevel);
         toplevel

--- a/src/lair/mod.rs
+++ b/src/lair/mod.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxBuildHasher;
 
 use crate::func;
 
-use self::{chipset::Nochip, toplevel::Toplevel};
+use self::{chipset::NoChip, toplevel::Toplevel};
 
 pub mod air;
 pub mod bytecode;
@@ -21,7 +21,7 @@ pub mod relations;
 pub mod toplevel;
 pub mod trace;
 
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Name(pub &'static str);
 
 impl std::fmt::Display for Name {
@@ -50,7 +50,7 @@ pub type List<T> = Box<[T]>;
 pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 #[allow(dead_code)]
-pub(crate) fn demo_toplevel<F: Field + Ord>() -> Toplevel<F, Nochip> {
+pub(crate) fn demo_toplevel<F: Field + Ord>() -> Toplevel<F, NoChip, NoChip> {
     let factorial_e = func!(
     fn factorial(n): [1] {
         let one = 1;

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -575,7 +575,7 @@ mod test {
     }
 
     fn read_wideptr(zstore: &mut ZStore<BabyBear, LurkChip>, src: &str) -> WidePtr {
-        let ZPtr { tag, digest } = zstore.read(src).unwrap();
+        let ZPtr { tag, digest } = zstore.read(src, &Default::default()).unwrap();
         wide_ptr(tag.elt(), digest)
     }
 
@@ -636,7 +636,9 @@ mod test {
 
         // Determine whether we want to use the intended in/out, or attack the program with the bad in/out
         if let Some((bad_input, bad_output)) = bad_input_output {
-            let bad_zptr = zstore.read(bad_input).expect("failed to read");
+            let bad_zptr = zstore
+                .read(bad_input, &Default::default())
+                .expect("failed to read");
             let bad_input = store.zptr_ptr(&bad_zptr).unwrap();
             let bad_output = vec![(read_wideptr(&mut zstore, bad_output),)];
 

--- a/src/loam/distilled_evaluation.rs
+++ b/src/loam/distilled_evaluation.rs
@@ -1040,7 +1040,7 @@ mod test {
     }
 
     fn read_wideptr(zstore: &mut ZStore<BabyBear, LurkChip>, src: &str) -> WidePtr {
-        let ZPtr { tag, digest } = zstore.read(src).unwrap();
+        let ZPtr { tag, digest } = zstore.read(src, &Default::default()).unwrap();
         wide_ptr(tag.elt(), digest)
     }
 

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -199,7 +199,7 @@ impl Tag {
     }
 }
 
-// Because it's hard to share code between ascent programs, this is a copy of `AllocationProgam`, replacing the `map_double` function
+// Because it's hard to share code between ascent programs, this is a copy of `AllocationProgram`, replacing the `map_double` function
 // with evaluation
 #[cfg(feature = "loam")]
 ascent! {
@@ -1232,7 +1232,7 @@ mod test {
     }
 
     fn read_wideptr(zstore: &mut ZStore<BabyBear, LurkChip>, src: &str) -> WidePtr {
-        let ZPtr { tag, digest } = zstore.read(src).unwrap();
+        let ZPtr { tag, digest } = zstore.read(src, &Default::default()).unwrap();
         wide_ptr(tag.elt(), digest)
     }
 
@@ -1391,8 +1391,8 @@ mod test {
     #[test]
     fn test_lambda() {
         let mut zstore = lurk_zstore();
-        let args = zstore.read("(x)").unwrap();
-        let body = zstore.read("(+ x 1)").unwrap();
+        let args = zstore.read("(x)", &Default::default()).unwrap();
+        let body = zstore.read("(+ x 1)", &Default::default()).unwrap();
         let env = *zstore.nil();
 
         let fun = zstore.intern_fun(args, body, env);

--- a/src/loam/memory.rs
+++ b/src/loam/memory.rs
@@ -490,7 +490,7 @@ impl Store {
     pub fn fmt(&self, zstore: &ZStore<LE, LurkChip>, ptr: &PPtr) -> String {
         match ptr.tag() {
             Tag::Num => format!("{}n", ptr.addr()),
-            Tag::Builtin | Tag::BigNum | Tag::Sym | Tag::Key => self
+            Tag::Builtin | Tag::BigNum | Tag::Sym | Tag::Key | Tag::Coroutine => self
                 .pptr_digest
                 .get(ptr)
                 .map(|digest| {
@@ -538,7 +538,7 @@ pub fn initial_builtin_relation() -> Vec<(Wide, Dual<LEWrap>)> {
         .iter()
         .enumerate()
         .map(|(i, name)| {
-            let ZPtr { tag, digest } = zstore.intern_symbol(name);
+            let ZPtr { tag, digest } = zstore.intern_symbol_no_lang(name);
 
             (Wide(digest), Dual(LEWrap(LE::from_canonical_u64(i as u64))))
         })

--- a/src/lurk/big_num.rs
+++ b/src/lurk/big_num.rs
@@ -122,7 +122,7 @@ mod test {
             lair_chip::{build_chip_vector, build_lair_chip_vector, LairMachineProgram},
             toplevel::Toplevel,
         },
-        lurk::chipset::lurk_chip_map,
+        lurk::chipset::lurk_chip_map_native,
     };
 
     #[test]
@@ -134,7 +134,7 @@ mod test {
             let c = extern_call(big_num_lessthan, a, b);
             return c
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[lessthan_func], lurk_chip_map);
 
         let lessthan_chip = FuncChip::from_name("lessthan", &toplevel);

--- a/src/lurk/cli/comm_data.rs
+++ b/src/lurk/cli/comm_data.rs
@@ -20,10 +20,10 @@ pub(crate) struct CommData<F: std::hash::Hash + Eq> {
 
 impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     #[inline]
-    pub(crate) fn new<H: Chipset<F>>(
+    pub(crate) fn new<C: Chipset<F>>(
         secret: ZPtr<F>,
         payload: ZPtr<F>,
-        zstore: &ZStore<F, H>,
+        zstore: &ZStore<F, C>,
     ) -> Self {
         assert_eq!(secret.tag, Tag::BigNum);
         let mut zdag = ZDag::default();
@@ -53,7 +53,7 @@ impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     }
 
     #[inline]
-    pub(crate) fn commit<H: Chipset<F>>(&self, zstore: &mut ZStore<F, H>) -> ZPtr<F>
+    pub(crate) fn commit<C: Chipset<F>>(&self, zstore: &mut ZStore<F, C>) -> ZPtr<F>
     where
         F: Field,
     {
@@ -61,7 +61,7 @@ impl<F: std::hash::Hash + Eq + Default + Copy> CommData<F> {
     }
 
     #[inline]
-    pub(crate) fn populate_zstore<H: Chipset<F>>(self, zstore: &mut ZStore<F, H>)
+    pub(crate) fn populate_zstore<C: Chipset<F>>(self, zstore: &mut ZStore<F, C>)
     where
         F: Field,
     {

--- a/src/lurk/cli/lurk_data.rs
+++ b/src/lurk/cli/lurk_data.rs
@@ -16,14 +16,14 @@ pub(crate) struct LurkData<F: std::hash::Hash + Eq> {
 
 impl<F: std::hash::Hash + Eq + Default + Copy> LurkData<F> {
     #[inline]
-    pub(crate) fn new<H: Chipset<F>>(zptr: ZPtr<F>, zstore: &ZStore<F, H>) -> Self {
+    pub(crate) fn new<C: Chipset<F>>(zptr: ZPtr<F>, zstore: &ZStore<F, C>) -> Self {
         let mut zdag = ZDag::default();
         zdag.populate_with(&zptr, zstore, &mut Default::default());
         Self { zptr, zdag }
     }
 
     #[inline]
-    pub(crate) fn populate_zstore<H: Chipset<F>>(self, zstore: &mut ZStore<F, H>) -> ZPtr<F>
+    pub(crate) fn populate_zstore<C: Chipset<F>>(self, zstore: &mut ZStore<F, C>) -> ZPtr<F>
     where
         F: AbstractField,
     {

--- a/src/lurk/cli/mod.rs
+++ b/src/lurk/cli/mod.rs
@@ -111,7 +111,7 @@ impl Cli {
 
 impl ReplCli {
     fn run(&self) -> Result<()> {
-        let mut repl = Repl::new();
+        let mut repl = Repl::new_native();
         if let Some(lurk_file) = &self.preload {
             repl.load_file(lurk_file, false)?;
         }
@@ -121,7 +121,7 @@ impl ReplCli {
 
 impl LoadCli {
     fn run(&self) -> Result<()> {
-        let mut repl = Repl::new();
+        let mut repl = Repl::new_native();
         repl.load_file(&self.lurk_file, self.demo)?;
         if self.prove {
             repl.prove_last_reduction()?;

--- a/src/lurk/cli/proofs.rs
+++ b/src/lurk/cli/proofs.rs
@@ -141,10 +141,10 @@ pub(crate) struct IOProof {
 }
 
 impl IOProof {
-    pub(crate) fn new<H: Chipset<F>>(
+    pub(crate) fn new<C: Chipset<F>>(
         crypto_proof: CryptoProof,
         public_values: &[F],
-        zstore: &ZStore<F, H>,
+        zstore: &ZStore<F, C>,
     ) -> Self {
         let mut zdag = ZDag::default();
         let (expr_data, rest) = public_values.split_at(ZPTR_SIZE);
@@ -184,10 +184,10 @@ pub(crate) struct ProtocolProof {
 
 impl ProtocolProof {
     #[inline]
-    pub(crate) fn new<H: Chipset<F>>(
+    pub(crate) fn new<C: Chipset<F>>(
         crypto_proof: CryptoProof,
         args: ZPtr<F>,
-        zstore: &ZStore<F, H>,
+        zstore: &ZStore<F, C>,
     ) -> Self {
         Self {
             crypto_proof,

--- a/src/lurk/cli/tests/mod.rs
+++ b/src/lurk/cli/tests/mod.rs
@@ -6,11 +6,11 @@ use crate::lurk::cli::{
 #[test]
 fn test_meta_commands() {
     set_config(Config::default());
-    let mut repl = Repl::new();
+    let mut repl = Repl::new_native();
     assert!(repl
         .load_file("src/lurk/cli/tests/first.lurk".into(), false)
         .is_ok());
-    let mut repl = Repl::new();
+    let mut repl = Repl::new_native();
     assert!(repl
         .load_file("src/lurk/cli/tests/second.lurk".into(), false)
         .is_ok());
@@ -21,11 +21,11 @@ fn test_meta_commands() {
 #[test]
 fn test_meta_commands_with_proofs() {
     set_config(Config::default());
-    let mut repl = Repl::new();
+    let mut repl = Repl::new_native();
     assert!(repl
         .load_file("src/lurk/cli/tests/prove.lurk".into(), false)
         .is_ok());
-    let mut repl = Repl::new();
+    let mut repl = Repl::new_native();
     assert!(repl
         .load_file("src/lurk/cli/tests/verify.lurk".into(), false)
         .is_ok());
@@ -36,6 +36,6 @@ fn test_meta_commands_with_proofs() {
 #[test]
 fn test_lib() {
     set_config(Config::default());
-    let mut repl = Repl::new();
+    let mut repl = Repl::new_native();
     assert!(repl.load_file("lib/tests.lurk".into(), false).is_ok());
 }

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -14,10 +14,10 @@ pub(crate) struct ZDag<F: std::hash::Hash + Eq>(FxHashMap<ZPtr<F>, ZPtrType<F>>)
 impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
     /// Traverses a ZStore DAG, starting from a given `ZPtr`, while populating
     /// itself.
-    pub(crate) fn populate_with<'a, H: Chipset<F>>(
+    pub(crate) fn populate_with<'a, C: Chipset<F>>(
         &mut self,
         zptr: &'a ZPtr<F>,
-        zstore: &'a ZStore<F, H>,
+        zstore: &'a ZStore<F, C>,
         cache: &mut FxHashSet<&'a ZPtr<F>>,
     ) {
         if cache.contains(zptr) {
@@ -44,10 +44,10 @@ impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
     }
 
     /// Calls `populate_with` for a sequence of `ZPtr`s
-    pub(crate) fn populate_with_many<'a, H: Chipset<F>>(
+    pub(crate) fn populate_with_many<'a, C: Chipset<F>>(
         &mut self,
         zptrs: impl IntoIterator<Item = &'a ZPtr<F>>,
-        zstore: &ZStore<F, H>,
+        zstore: &ZStore<F, C>,
     ) where
         F: 'a,
     {
@@ -58,7 +58,7 @@ impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
     }
 
     /// Moves its data to a target ZStore
-    pub(crate) fn populate_zstore<H: Chipset<F>>(self, zstore: &mut ZStore<F, H>)
+    pub(crate) fn populate_zstore<C: Chipset<F>>(self, zstore: &mut ZStore<F, C>)
     where
         F: AbstractField + Copy,
     {

--- a/src/lurk/lang.rs
+++ b/src/lurk/lang.rs
@@ -1,0 +1,78 @@
+use crate::lair::{chipset::NoChip, expr::FuncE, FxIndexMap, Name};
+
+use super::symbol::Symbol;
+
+/// Carries the coroutine implementation as a Lair function and informs its
+/// characteristics
+pub struct Coroutine<F> {
+    /// The arity of the coroutine in Lurk code. For example, `my-coroutine` in
+    /// `(my-coroutine a b)` has `lurk_arity` 2.
+    pub lurk_arity: usize,
+    /// Whether the Lair function should take the reduction environment as a
+    /// parameter
+    pub uses_env: bool,
+    /// The actual implementation of the coroutine. The Lair function must have
+    /// arity equal `2 * lurk_arity + usize::from(uses_env)`. That's because
+    /// each Lurk argument has a tag and a value and then the environment, if
+    /// requested, is provided as the last argument. Additionally, the Lair
+    /// function must have output size 2: a tag and a value.
+    pub func_expr: FuncE<F>,
+}
+
+/// A `Lang` specifies how to extend Lurk with custom coroutines and gadgets.
+///
+/// Each coroutine is called, in Lurk, by the symbol associated with it. The
+/// precise behavior is implemented as a Lair function, which can further call
+/// custom gadgets by their names.
+///
+/// Important:
+/// * Coroutine symbols must not conflict with Lurk's native symbols from the
+///   `.lurk` and `.lurk.builtin` packages
+/// * The names of the Lair functions must not conflict with the names of
+///   native Lair functions' from Lurk's `Toplevel`
+/// * The gadget names must not conflict with native gadget names from Lurk's
+///   `Chipset`
+pub struct Lang<F, C> {
+    coroutines: FxIndexMap<Symbol, Coroutine<F>>,
+    gadgets: FxIndexMap<Name, C>,
+}
+
+impl<F, C> Lang<F, C> {
+    #[inline]
+    pub fn new<
+        IF: IntoIterator<Item = (Symbol, Coroutine<F>)>,
+        IC: IntoIterator<Item = (Name, C)>,
+    >(
+        coroutines: IF,
+        gadgets: IC,
+    ) -> Self {
+        Self {
+            coroutines: coroutines.into_iter().collect(),
+            gadgets: gadgets.into_iter().collect(),
+        }
+    }
+
+    #[inline]
+    pub fn into_parts(self) -> (FxIndexMap<Symbol, Coroutine<F>>, FxIndexMap<Name, C>) {
+        let Self {
+            coroutines,
+            gadgets,
+        } = self;
+        (coroutines, gadgets)
+    }
+
+    #[inline]
+    pub fn coroutines(&self) -> &FxIndexMap<Symbol, Coroutine<F>> {
+        &self.coroutines
+    }
+}
+
+impl<F> Lang<F, NoChip> {
+    #[inline]
+    pub fn empty() -> Lang<F, NoChip> {
+        Lang {
+            coroutines: FxIndexMap::default(),
+            gadgets: FxIndexMap::default(),
+        }
+    }
+}

--- a/src/lurk/mod.rs
+++ b/src/lurk/mod.rs
@@ -4,8 +4,7 @@ pub mod big_num;
 pub mod chipset;
 pub mod cli;
 pub mod eval;
-#[cfg(test)]
-mod eval_tests;
+pub mod lang;
 pub mod package;
 pub mod parser;
 pub mod poseidon;
@@ -15,3 +14,6 @@ pub mod syntax;
 pub mod tag;
 pub mod u64;
 pub mod zstore;
+
+#[cfg(test)]
+mod tests;

--- a/src/lurk/tag.rs
+++ b/src/lurk/tag.rs
@@ -35,6 +35,7 @@ pub enum Tag {
     Env,
     Thunk,
     Err,
+    Coroutine,
 }
 
 impl Tag {
@@ -65,7 +66,7 @@ mod test {
 
     #[test]
     fn test_strum() {
-        assert_eq!(14, Tag::COUNT);
+        assert_eq!(15, Tag::COUNT);
         assert_eq!(Tag::COUNT, Tag::iter().count());
     }
 

--- a/src/lurk/tests/lang.rs
+++ b/src/lurk/tests/lang.rs
@@ -1,0 +1,238 @@
+//! Tests for the correct coupling of custom coroutines and gadgets
+
+use once_cell::sync::OnceCell;
+use p3_air::AirBuilder;
+use p3_baby_bear::BabyBear;
+use p3_field::AbstractField;
+use rustc_hash::FxHashSet;
+use sphinx_core::utils::BabyBearPoseidon2;
+
+use crate::{
+    func,
+    lair::{chipset::Chipset, toplevel::Toplevel, Name},
+    lurk::{
+        chipset::LurkChip,
+        eval::{build_lurk_toplevel, EvalErr},
+        lang::{Coroutine, Lang},
+        state::user_sym,
+        symbol::Symbol,
+        tag::Tag,
+        zstore::{ZPtr, ZStore},
+    },
+};
+
+use super::run_tests;
+
+struct SquareGadget;
+
+impl<F: AbstractField> Chipset<F> for SquareGadget {
+    fn input_size(&self) -> usize {
+        1
+    }
+
+    fn output_size(&self) -> usize {
+        1
+    }
+
+    fn execute_simple(&self, input: &[F]) -> Vec<F> {
+        vec![input[0].clone() * input[0].clone()]
+    }
+
+    fn witness_size(&self) -> usize {
+        1
+    }
+
+    fn require_size(&self) -> usize {
+        0
+    }
+
+    fn populate_witness(&self, input: &[F], witness: &mut [F]) -> Vec<F> {
+        witness[0] = input[0].clone() * input[0].clone();
+        witness[..1].to_vec()
+    }
+
+    fn eval<AB: crate::air::builder::LookupBuilder>(
+        &self,
+        builder: &mut AB,
+        is_real: AB::Expr,
+        input: Vec<AB::Expr>,
+        witness: &[AB::Var],
+        _nonce: AB::Expr,
+        _requires: &[crate::air::builder::RequireRecord<AB::Var>],
+    ) -> Vec<AB::Expr> {
+        builder
+            .when(is_real)
+            .assert_eq(input[0].clone() * input[0].clone(), witness[0]);
+        vec![witness[0].into()]
+    }
+}
+
+fn extern_square<F: AbstractField>() -> Coroutine<F> {
+    let func_expr = func!(
+        fn extern_square(num_tag, num): [2] {
+            match num_tag {
+                Tag::Num => {
+                    let squared = extern_call(square_gadget, num);
+                    return (num_tag, squared)
+                }
+            };
+            let err_tag = Tag::Err;
+            let err = EvalErr::InvalidArg;
+            return (err_tag, err)
+        }
+    );
+    Coroutine {
+        lurk_arity: 1,
+        func_expr,
+        uses_env: false,
+    }
+}
+
+fn mul_square<F: AbstractField>() -> Coroutine<F> {
+    let func_expr = func!(
+        fn mul_square(num_tag, num): [2] {
+            match num_tag {
+                Tag::Num => {
+                    let squared = mul(num, num);
+                    return (num_tag, squared)
+                }
+            };
+            let err_tag = Tag::Err;
+            let err = EvalErr::InvalidArg;
+            return (err_tag, err)
+        }
+    );
+    Coroutine {
+        lurk_arity: 1,
+        func_expr,
+        uses_env: false,
+    }
+}
+
+fn square_lang<F: AbstractField>() -> Lang<F, SquareGadget> {
+    Lang::new(
+        [
+            (user_sym("extern-square"), extern_square()),
+            (user_sym("mul-square"), mul_square()),
+        ],
+        [(Name("square_gadget"), SquareGadget)],
+    )
+}
+
+type F = BabyBear;
+
+#[allow(clippy::type_complexity)]
+static TEST_SETUP_DATA: OnceCell<(
+    FxHashSet<Symbol>,
+    Toplevel<F, LurkChip, SquareGadget>,
+    ZStore<F, LurkChip>,
+    BabyBearPoseidon2,
+)> = OnceCell::new();
+
+#[allow(clippy::type_complexity)]
+fn test_setup_data() -> &'static (
+    FxHashSet<Symbol>,
+    Toplevel<F, LurkChip, SquareGadget>,
+    ZStore<F, LurkChip>,
+    BabyBearPoseidon2,
+) {
+    TEST_SETUP_DATA.get_or_init(|| {
+        let lang = square_lang();
+        let (toplevel, zstore, lang_symbols) = build_lurk_toplevel(lang);
+        let config = BabyBearPoseidon2::new();
+        (lang_symbols, toplevel, zstore, config)
+    })
+}
+
+fn test_case(input_code: &'static str, expected_cloj: fn(&mut ZStore<F, LurkChip>) -> ZPtr<F>) {
+    let (lang_symbols, toplevel, zstore, config) = test_setup_data();
+    let mut zstore = zstore.clone();
+    let zptr = zstore.read(input_code, lang_symbols).expect("Read failure");
+    run_tests(
+        &zptr,
+        &ZPtr::null(Tag::Env),
+        toplevel,
+        &mut zstore,
+        expected_cloj,
+        config.clone(),
+    );
+}
+
+macro_rules! test {
+    ($test_func:ident, $input_code:expr, $expected_cloj:expr) => {
+        #[test]
+        fn $test_func() {
+            test_case($input_code, $expected_cloj)
+        }
+    };
+}
+
+fn num(n: u32) -> ZPtr<F> {
+    ZPtr::num(F::from_canonical_u32(n))
+}
+
+test!(test_mul, "(mul-square (+ 1n 2n))", |_| num(9));
+test!(test_extern, "(extern-square (+ 1n 2n))", |_| num(9));
+
+test!(test_mul_undersaturated, "(mul-square)", |_| ZPtr::err(
+    EvalErr::InvalidForm
+));
+test!(
+    test_extern_undersaturated,
+    "(extern-square)",
+    |_| ZPtr::err(EvalErr::InvalidForm)
+);
+
+test!(test_mul_oversaturated, "(mul-square 3n 2n)", |_| ZPtr::err(
+    EvalErr::InvalidForm
+));
+test!(test_extern_oversaturated, "(extern-square 3n 2n)", |_| {
+    ZPtr::err(EvalErr::InvalidForm)
+});
+
+test!(test_mul_mistype, "(mul-square 3)", |_| ZPtr::err(
+    EvalErr::InvalidArg
+));
+test!(test_extern_mistype, "(extern-square 3)", |_| ZPtr::err(
+    EvalErr::InvalidArg
+));
+
+test!(test_mul_arg_err, "(mul-square a)", |_| ZPtr::err(
+    EvalErr::UnboundVar
+));
+test!(test_extern_arg_err, "(extern-square a)", |_| ZPtr::err(
+    EvalErr::UnboundVar
+));
+
+test!(
+    test_mul_shadow1,
+    "(let ((mul-square 1n)) mul-square)",
+    |_| num(1)
+);
+test!(
+    test_extern_shadow1,
+    "(let ((extern-square 1n)) extern-square)",
+    |_| num(1)
+);
+
+test!(
+    test_mul_shadow2,
+    "(letrec ((mul-square 1n)) mul-square)",
+    |_| num(1)
+);
+test!(
+    test_extern_shadow2,
+    "(letrec ((extern-square 1n)) extern-square)",
+    |_| num(1)
+);
+
+test!(
+    test_mul_shadow3,
+    "((lambda (mul-square) (+ mul-square 1n)) 2n)",
+    |_| num(3)
+);
+test!(
+    test_extern_shadow3,
+    "((lambda (extern-square) (+ extern-square 1n)) 2n)",
+    |_| num(3)
+);

--- a/src/lurk/tests/mod.rs
+++ b/src/lurk/tests/mod.rs
@@ -1,0 +1,71 @@
+mod eval;
+mod lang;
+
+use p3_baby_bear::BabyBear as F;
+use p3_field::AbstractField;
+use sphinx_core::{stark::StarkMachine, utils::BabyBearPoseidon2};
+
+use crate::{
+    air::debug::debug_chip_constraints_and_queries_with_sharding,
+    lair::{
+        chipset::Chipset,
+        execute::{QueryRecord, Shard, ShardingConfig},
+        func_chip::FuncChip,
+        lair_chip::{
+            build_chip_vector_from_lair_chips, build_lair_chip_vector, LairMachineProgram,
+        },
+        toplevel::Toplevel,
+    },
+    lurk::{
+        chipset::LurkChip,
+        zstore::{ZPtr, ZStore},
+    },
+};
+
+fn run_tests<C2: Chipset<F>>(
+    zptr: &ZPtr<F>,
+    env: &ZPtr<F>,
+    toplevel: &Toplevel<F, LurkChip, C2>,
+    zstore: &mut ZStore<F, LurkChip>,
+    expected_cloj: fn(&mut ZStore<F, LurkChip>) -> ZPtr<F>,
+    config: BabyBearPoseidon2,
+) {
+    let mut record = QueryRecord::new(toplevel);
+    let hashes3 = std::mem::take(&mut zstore.hashes3_diff);
+    let hashes4 = std::mem::take(&mut zstore.hashes4_diff);
+    let hashes5 = std::mem::take(&mut zstore.hashes5_diff);
+    record.inject_inv_queries_owned("hash3", toplevel, hashes3);
+    record.inject_inv_queries_owned("hash4", toplevel, hashes4);
+    record.inject_inv_queries_owned("hash5", toplevel, hashes5);
+
+    let mut input = [F::zero(); 24];
+    input[..16].copy_from_slice(&zptr.flatten());
+    input[16..].copy_from_slice(&env.digest);
+
+    let lurk_main = FuncChip::from_name("lurk_main", toplevel);
+    let result = toplevel
+        .execute(lurk_main.func, &input, &mut record, None)
+        .unwrap();
+
+    assert_eq!(result.as_ref(), &expected_cloj(zstore).flatten());
+
+    let lair_chips = build_lair_chip_vector(&lurk_main);
+
+    // debug constraints and verify lookup queries with and without sharding
+    debug_chip_constraints_and_queries_with_sharding(&record, &lair_chips, None);
+    debug_chip_constraints_and_queries_with_sharding(
+        &record,
+        &lair_chips,
+        Some(ShardingConfig { max_shard_size: 4 }),
+    );
+
+    // debug constraints with Sphinx
+    let full_shard = Shard::new(&record);
+    let machine = StarkMachine::new(
+        config,
+        build_chip_vector_from_lair_chips(lair_chips),
+        record.expect_public_values().len(),
+    );
+    let (pk, _) = machine.setup(&LairMachineProgram);
+    machine.debug_constraints(&pk, full_shard);
+}

--- a/src/lurk/u64.rs
+++ b/src/lurk/u64.rs
@@ -236,7 +236,7 @@ mod test {
             lair_chip::{build_chip_vector, build_lair_chip_vector, LairMachineProgram},
             toplevel::Toplevel,
         },
-        lurk::chipset::lurk_chip_map,
+        lurk::chipset::lurk_chip_map_native,
     };
 
     #[test]
@@ -248,7 +248,7 @@ mod test {
             let c: [8] = extern_call(u64_add, a, b);
             return c
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[add_func], lurk_chip_map);
 
         let add_chip = FuncChip::from_name("add", &toplevel);
@@ -306,7 +306,7 @@ mod test {
             let c: [8] = extern_call(u64_sub, a, b);
             return c
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[sub_func], lurk_chip_map);
 
         let sub_chip = FuncChip::from_name("sub", &toplevel);
@@ -368,7 +368,7 @@ mod test {
             let g: [8] = extern_call(u64_mul, f, f);
             return g
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[mul_func], lurk_chip_map);
 
         let mul_chip = FuncChip::from_name("mul", &toplevel);
@@ -426,7 +426,7 @@ mod test {
             let (div: [8], rem: [8]) = extern_call(u64_divrem, a, b);
             return (div, rem)
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[divrem_func], lurk_chip_map);
 
         let divrem_chip = FuncChip::from_name("divrem", &toplevel);
@@ -502,7 +502,7 @@ mod test {
             let c = extern_call(u64_lessthan, a, b);
             return c
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[lessthan_func], lurk_chip_map);
 
         let lessthan_chip = FuncChip::from_name("lessthan", &toplevel);
@@ -557,7 +557,7 @@ mod test {
             let c = extern_call(u64_iszero, a);
             return c
         });
-        let lurk_chip_map = lurk_chip_map();
+        let lurk_chip_map = lurk_chip_map_native();
         let toplevel = Toplevel::new(&[iszero_func], lurk_chip_map);
 
         let iszero_chip = FuncChip::from_name("iszero", &toplevel);


### PR DESCRIPTION
A whole bunch of changes in order to enable user-made gadgets through `Lang`.

Differently from Lurk Beta and R1CS, this patch empowers the user with the full blown expressiveness of Lair - not just Air.

There are changes in Lair to support an extra `Chipset` type, but most of the significant changes are in Lurk itself.