### PR TITLE
feat: `eqq` built-in

### DIFF
--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -263,7 +263,7 @@ const USER_PACKAGE_NAME: &str = "lurk-user";
 
 pub(crate) const LURK_SYMBOLS: [&str; 3] = ["nil", "t", "&rest"];
 
-pub(crate) const BUILTIN_SYMBOLS: [&str; 40] = [
+pub(crate) const BUILTIN_SYMBOLS: [&str; 41] = [
     "atom",
     "apply",
     "begin",
@@ -279,6 +279,7 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 40] = [
     "empty-env",
     "eval",
     "eq",
+    "eqq",
     "type-eq",
     "type-eqq",
     "hide",

--- a/src/lurk/tests/eval.rs
+++ b/src/lurk/tests/eval.rs
@@ -319,6 +319,9 @@ test_raw!(
 test!(test_eq22, "(eq 1n 0n)", |z| *z.nil());
 test!(test_eq23, "(eq 1n 1n)", |z| *z.t());
 
+test!(test_eqq, "(eqq (1 . 2) (cons 1 2))", |z| *z.t());
+test!(test_eqq2, "(eqq (cons 1 2) (cons 1 2))", |z| *z.nil());
+
 test!(
     test_misc1,
     "(letrec ((ones (cons 1 (lambda () ones))))


### PR DESCRIPTION
Implement `eqq`, which is similar to `eq` but doesn't evaluate the first argument.