### PR TITLE
fix: speed up ascent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,3 +166,8 @@ codegen-units = 16
 [features]
 default=[]
 loam=[]
+
+
+# Ascent will be compiled with -Copt-level=3 . This includes build dependencies.
+[profile.dev.package."ascent"]
+opt-level = 3


### PR DESCRIPTION
This trick makes loam use an ascent package (including its dependencies, therefore including ascent-derive) that's compiled in release mode, even in debug builds.

Saves a few seconds in my IDE. 