### PR TITLE
fix: transitin meta command

### DIFF
--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -560,12 +560,6 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> MetaCmd<F, C1, C2> {
         if current_state.tag != Tag::Cons {
             bail!("Current state must reduce to a pair");
         }
-        // reduce `call_args` elements
-        let list_sym = repl
-            .zstore
-            .intern_symbol(&builtin_sym("list"), &repl.lang_symbols);
-        let list_expr = repl.zstore.intern_cons(list_sym, call_args);
-        let (call_args, _) = repl.reduce_aux(&list_expr)?;
         repl.memoize_dag(current_state.tag, &current_state.digest);
         let (_, &callable) = repl.zstore.fetch_tuple2(&current_state);
         let call_expr = repl.zstore.intern_cons(callable, call_args);

--- a/src/lurk/cli/tests/mod.rs
+++ b/src/lurk/cli/tests/mod.rs
@@ -39,3 +39,22 @@ fn test_lib() {
     let mut repl = Repl::new_native();
     assert!(repl.load_file("lib/tests.lurk".into(), false).is_ok());
 }
+
+#[ignore]
+#[test]
+fn test_demo_files() {
+    set_config(Config::default());
+    let demo_files = [
+        "demo/simple.lurk",
+        "demo/functional-commitment.lurk",
+        "demo/chained-functional-commitment.lurk",
+        "demo/protocol.lurk",
+        "demo/bank.lurk",
+        "demo/mastermind.lurk",
+    ];
+    for file in demo_files {
+        let mut repl = Repl::new_native();
+        assert!(repl.load_file(file.into(), false).is_ok());
+    }
+    std::fs::remove_file("protocol-proof").unwrap();
+}

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -2095,12 +2095,8 @@ pub fn apply<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
             // Expression must be a function
             let head_not_fun = sub(head_tag, fun_tag);
             if head_not_fun {
-                let head_not_err = sub(head_tag, fun_tag);
-                if head_not_err {
-                    let err = EvalErr::ApplyNonFunc;
-                    return (err_tag, err)
-                }
-                return (err_tag, head)
+                let err = EvalErr::ApplyNonFunc;
+                return (err_tag, err)
             }
 
             let (params_tag, params, body_tag, body, func_env) = load(head);
@@ -2355,7 +2351,7 @@ mod test {
         expect_eq(equal.width(), expect!["86"]);
         expect_eq(equal_inner.width(), expect!["59"]);
         expect_eq(car_cdr.width(), expect!["61"]);
-        expect_eq(apply.width(), expect!["115"]);
+        expect_eq(apply.width(), expect!["114"]);
         expect_eq(env_lookup.width(), expect!["52"]);
         expect_eq(ingress.width(), expect!["105"]);
         expect_eq(egress.width(), expect!["82"]);


### PR DESCRIPTION
Remove code that was evaluating transition arguments, as that might turn expressions such as `'(1 2 3)` into `(1 2 3)`, which is not a valid argument for a call.

Extra:
* Remove useless path in `apply` coroutine
* Add a test for the demo files