### PR TITLE
chore: changes in the microchain API

### DIFF
--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -339,7 +339,7 @@ const META_SYMBOLS: [&str; 34] = [
     "defprotocol",
     "prove-protocol",
     "verify-protocol",
-    "micro-chain-serve",
-    "micro-chain-get",
-    "micro-chain-transition",
+    "microchain-serve",
+    "microchain-get",
+    "microchain-transition",
 ];


### PR DESCRIPTION
The meta commands now start with `microchain` instead of `micro-chain`.

Also, the address is now evaluated so the user doesn't need to hardcode it everytime.