### PR TITLE
chore: revamp the microchain API

### DIFF
--- a/src/lurk/cli/lurk_data.rs
+++ b/src/lurk/cli/lurk_data.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::zdag::ZDag;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct LurkData<F: std::hash::Hash + Eq> {
     pub(crate) zptr: ZPtr<F>,
     zdag: ZDag<F>,

--- a/src/lurk/cli/microchain.rs
+++ b/src/lurk/cli/microchain.rs
@@ -1,0 +1,328 @@
+use anyhow::Result;
+use clap::Args;
+use p3_baby_bear::BabyBear;
+use p3_field::{AbstractField, PrimeField32};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use sphinx_core::stark::StarkGenericConfig;
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use crate::{
+    lair::{chipset::Chipset, lair_chip::LairMachineProgram},
+    lurk::{
+        chipset::LurkChip,
+        eval::build_lurk_toplevel,
+        lang::Lang,
+        stark_machine::new_machine,
+        zstore::{ZPtr, ZStore, DIGEST_SIZE},
+    },
+};
+
+use super::{
+    comm_data::CommData,
+    lurk_data::LurkData,
+    proofs::get_verifier_version,
+    proofs::{ChainProof, OpaqueChainProof},
+};
+
+#[derive(Args, Debug)]
+pub(crate) struct MicrochainArgs {
+    // The IP address with the port. E.g. "127.0.0.1:1234"
+    #[clap(value_parser)]
+    addr: String,
+}
+
+type F = BabyBear;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) enum CallableData {
+    Comm(CommData<F>),
+    Fun(LurkData<F>),
+}
+
+impl CallableData {
+    fn has_opaque_data(&self) -> bool {
+        match self {
+            Self::Comm(comm_data) => comm_data.payload_has_opaque_data(),
+            Self::Fun(lurk_data) => lurk_data.has_opaque_data(),
+        }
+    }
+
+    fn zptr(&self, zstore: &mut ZStore<F, LurkChip>) -> ZPtr<F> {
+        match self {
+            Self::Comm(comm_data) => comm_data.commit(zstore),
+            Self::Fun(lurk_data) => lurk_data.zptr,
+        }
+    }
+}
+
+/// Encodes a `(chain-result . callable)` pair, the result of chaining a callable.
+/// The pair components carry the corresponding `ZDag`s in order to be fully
+/// transferable between clients (through the server)
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct ChainState {
+    pub(crate) chain_result: LurkData<F>,
+    pub(crate) callable_data: CallableData,
+}
+
+impl ChainState {
+    pub(crate) fn into_zptr<C1: Chipset<F>>(self, zstore: &mut ZStore<F, C1>) -> ZPtr<F> {
+        let Self {
+            chain_result,
+            callable_data,
+        } = self;
+        let chain_result_zptr = chain_result.populate_zstore(zstore);
+        let callable_zptr = match callable_data {
+            CallableData::Comm(comm_data) => {
+                let zptr = comm_data.commit(zstore);
+                comm_data.populate_zstore(zstore);
+                zptr
+            }
+            CallableData::Fun(lurk_data) => lurk_data.populate_zstore(zstore),
+        };
+        zstore.intern_cons(chain_result_zptr, callable_zptr)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) enum Request {
+    Start(ChainState),
+    GetGenesis([F; DIGEST_SIZE]),
+    GetState([F; DIGEST_SIZE]),
+    Transition([F; DIGEST_SIZE], ChainProof),
+    GetProofs([F; DIGEST_SIZE]),
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) enum Response {
+    BadRequest,
+    IdSecret([F; DIGEST_SIZE]),
+    NoDataForId,
+    Genesis([F; DIGEST_SIZE], ChainState),
+    State(ChainState),
+    ChainResultIsOpaque,
+    NextCallableIsOpaque,
+    ProofVerificationFailed(String),
+    ProofAccepted,
+    Proofs(Vec<OpaqueChainProof>),
+}
+
+/// Holds the data for a microchain, mapped from an ID
+struct ChainData {
+    /// The data for the genesis state also contains the secret used to generate
+    /// the microchain ID
+    genesis: ([F; DIGEST_SIZE], ChainState),
+    /// Sequence of chain proofs, from the first transition to the latest
+    proofs: Vec<OpaqueChainProof>,
+    /// Current state of a microchain
+    state: ChainState,
+}
+
+impl MicrochainArgs {
+    pub(crate) fn run(self) -> Result<()> {
+        let MicrochainArgs { addr } = self;
+        let listener = TcpListener::bind(&addr)?;
+        println!("Listening at {addr}");
+
+        let (toplevel, mut zstore, _) = build_lurk_toplevel(Lang::empty());
+        let empty_env = zstore.intern_empty_env();
+
+        // chain id -> chain data
+        let mut chains = FxHashMap::default();
+
+        for stream in listener.incoming() {
+            match stream {
+                Ok(mut stream) => {
+                    macro_rules! return_msg {
+                        ($data:expr) => {{
+                            write_data(&mut stream, $data)?;
+                            continue;
+                        }};
+                    }
+                    let Ok(request) = read_data::<Request>(&mut stream) else {
+                        return_msg!(Response::BadRequest);
+                    };
+                    match request {
+                        Request::Start(chain_state) => {
+                            if chain_state.chain_result.has_opaque_data() {
+                                return_msg!(Response::ChainResultIsOpaque);
+                            }
+                            if chain_state.callable_data.has_opaque_data() {
+                                return_msg!(Response::NextCallableIsOpaque);
+                            }
+
+                            let chain_result_zptr = chain_state.chain_result.zptr;
+                            let callable_zptr = chain_state.callable_data.zptr(&mut zstore);
+                            let (id_secret, id) =
+                                generate_id(chain_result_zptr, callable_zptr, &mut zstore);
+
+                            let chain_data = ChainData {
+                                genesis: (id_secret, chain_state.clone()),
+                                proofs: vec![],
+                                state: chain_state,
+                            };
+                            assert!(chains.insert(id, chain_data).is_none());
+                            return_msg!(Response::IdSecret(id_secret));
+                        }
+                        Request::GetGenesis(id) => {
+                            let Some(ChainData {
+                                genesis: (id_secret, state),
+                                ..
+                            }) = chains.get(&id)
+                            else {
+                                return_msg!(Response::NoDataForId);
+                            };
+                            return_msg!(Response::Genesis(*id_secret, state.clone()))
+                        }
+                        Request::GetState(id) => {
+                            let Some(ChainData { state, .. }) = chains.get(&id) else {
+                                return_msg!(Response::NoDataForId);
+                            };
+                            return_msg!(Response::State(state.clone()));
+                        }
+                        Request::Transition(id, chain_proof) => {
+                            let Some(ChainData { proofs, state, .. }) = chains.get_mut(&id) else {
+                                return_msg!(Response::NoDataForId);
+                            };
+
+                            let ChainProof {
+                                crypto_proof,
+                                call_args,
+                                next_chain_result,
+                                next_callable,
+                            } = chain_proof;
+
+                            let next_chain_result_zptr = {
+                                if next_chain_result.has_opaque_data() {
+                                    return_msg!(Response::ChainResultIsOpaque);
+                                }
+                                next_chain_result.zptr
+                            };
+
+                            let next_callable_zptr = match &next_callable {
+                                CallableData::Comm(comm_data) => {
+                                    if comm_data.payload_has_opaque_data() {
+                                        return_msg!(Response::NextCallableIsOpaque);
+                                    }
+                                    comm_data.commit(&mut zstore)
+                                }
+                                CallableData::Fun(lurk_data) => {
+                                    if lurk_data.has_opaque_data() {
+                                        return_msg!(Response::NextCallableIsOpaque);
+                                    }
+                                    lurk_data.zptr
+                                }
+                            };
+
+                            // the expression is a call whose callable is part of the server state
+                            // and the arguments are provided by the client
+                            let callable_zptr = state.callable_data.zptr(&mut zstore);
+                            let expr = zstore.intern_cons(callable_zptr, call_args);
+
+                            // the result is a pair composed by the chain result and next callable
+                            // provided by the client
+                            let result =
+                                zstore.intern_cons(next_chain_result_zptr, next_callable_zptr);
+
+                            // and now the proof must verify, meaning that the user must have
+                            // used the correct callable from the server state
+                            let machine_proof =
+                                crypto_proof.into_machine_proof(&expr, &empty_env, &result);
+                            let machine = new_machine(&toplevel);
+                            let (_, vk) = machine.setup(&LairMachineProgram);
+                            let challenger = &mut machine.config().challenger();
+                            if machine.verify(&vk, &machine_proof, challenger).is_err() {
+                                let verifier_version = get_verifier_version().to_string();
+                                return_msg!(Response::ProofVerificationFailed(verifier_version));
+                            }
+
+                            // everything went okay... transition to the next state
+
+                            // store new proof
+                            proofs.push(OpaqueChainProof {
+                                crypto_proof: machine_proof.into(),
+                                call_args,
+                                next_chain_result: next_chain_result_zptr,
+                                next_callable: next_callable_zptr,
+                            });
+
+                            // update the state
+                            *state = ChainState {
+                                chain_result: next_chain_result,
+                                callable_data: next_callable,
+                            };
+
+                            return_msg!(Response::ProofAccepted);
+                        }
+                        Request::GetProofs(id) => {
+                            let Some(ChainData { proofs, .. }) = chains.get(&id) else {
+                                return_msg!(Response::NoDataForId);
+                            };
+                            return_msg!(Response::Proofs(proofs.clone()));
+                        }
+                    }
+                }
+                Err(e) => eprintln!("Connection failed: {e}"),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns a `(secret, digest)` pair s.t. `secret` is randomly generated from a
+/// timestamp-based seed and `digest` is a hiding commitment that uses `secret`
+/// and whose payload the `Cons` pair formed with `chain_result_zptr` and
+/// `callable_zptr`.
+fn generate_id(
+    chain_result_zptr: ZPtr<F>,
+    callable_zptr: ZPtr<F>,
+    zstore: &mut ZStore<F, LurkChip>,
+) -> ([F; DIGEST_SIZE], [F; DIGEST_SIZE]) {
+    // TODO: factor this snippet out in order to implement the `rand` meta command
+    let mut id_secret = [F::zero(); DIGEST_SIZE];
+    let mut rng = ChaCha8Rng::seed_from_u64(timestamp_seed());
+    for limb in id_secret.iter_mut().take(DIGEST_SIZE) {
+        *limb = F::from_canonical_u32(rng.gen_range(0..F::ORDER_U32));
+    }
+
+    let cons = zstore.intern_cons(chain_result_zptr, callable_zptr);
+    let id_digest = CommData::hash(&id_secret, &cons, zstore);
+
+    (id_secret, id_digest)
+}
+
+fn timestamp_seed() -> u64 {
+    let duration_since_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+
+    let seconds_part = duration_since_epoch.as_secs();
+    let nanos_part = duration_since_epoch.subsec_nanos();
+
+    (seconds_part << 32) | u64::from(nanos_part)
+}
+
+pub(crate) fn read_data<T: for<'a> Deserialize<'a>>(stream: &mut TcpStream) -> Result<T> {
+    let mut size_bytes = [0; 8];
+    stream.read_exact(&mut size_bytes)?;
+    let size = usize::from_le_bytes(size_bytes);
+    let mut data_buffer = vec![0; size];
+    stream.read_exact(&mut data_buffer)?;
+    let data = bincode::deserialize(&data_buffer)?;
+    Ok(data)
+}
+
+pub(crate) fn write_data<T: Serialize>(stream: &mut TcpStream, data: T) -> Result<()> {
+    let data_bytes = bincode::serialize(&data)?;
+    stream.write_all(&data_bytes.len().to_le_bytes())?;
+    stream.write_all(&data_bytes)?;
+    stream.flush()?;
+    Ok(())
+}

--- a/src/lurk/cli/mod.rs
+++ b/src/lurk/cli/mod.rs
@@ -3,6 +3,7 @@ mod config;
 mod debug;
 mod lurk_data;
 mod meta;
+mod microchain;
 mod paths;
 mod proofs;
 pub mod repl;
@@ -14,6 +15,7 @@ use anyhow::{bail, Result};
 use camino::Utf8PathBuf;
 use clap::{Args, Parser, Subcommand};
 use config::{set_config, Config};
+use microchain::MicrochainArgs;
 use repl::Repl;
 
 #[derive(Parser, Debug)]
@@ -29,6 +31,8 @@ enum Command {
     Repl(ReplArgs),
     /// Loads a file, processing forms sequentially ("load" can be elided)
     Load(LoadArgs),
+    /// Starts the microchain server
+    Microchain(MicrochainArgs),
 }
 
 #[derive(Args, Debug)]
@@ -72,8 +76,8 @@ struct LoadCli {
 }
 
 fn parse_filename(file: &str) -> Result<Utf8PathBuf> {
-    if file == "help" {
-        bail!("\"help\" is not a valid filename. Printing help console instead");
+    if ["help", "microchain"].contains(&file) {
+        bail!("Invalid file name");
     }
     Ok(file.into())
 }
@@ -105,6 +109,7 @@ impl Cli {
         match self.command {
             Command::Repl(repl_args) => repl_args.into_cli().run(),
             Command::Load(load_args) => load_args.into_cli().run(),
+            Command::Microchain(microchain_args) => microchain_args.run(),
         }
     }
 }

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Holds Lurk data meant to be persisted and/or shared
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize, Clone)]
 pub(crate) struct ZDag<F: std::hash::Hash + Eq>(FxHashMap<ZPtr<F>, ZPtrType<F>>);
 
 impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {

--- a/src/lurk/mod.rs
+++ b/src/lurk/mod.rs
@@ -8,6 +8,7 @@ pub mod lang;
 pub mod package;
 pub mod parser;
 pub mod poseidon;
+pub mod stark_machine;
 pub mod state;
 pub mod symbol;
 pub mod syntax;

--- a/src/lurk/stark_machine.rs
+++ b/src/lurk/stark_machine.rs
@@ -1,0 +1,30 @@
+use p3_baby_bear::BabyBear;
+use sphinx_core::{
+    stark::StarkMachine,
+    utils::{BabyBearPoseidon2, DIGEST_SIZE},
+};
+
+use crate::lair::{
+    chipset::Chipset,
+    func_chip::FuncChip,
+    lair_chip::{build_chip_vector, LairChip},
+    toplevel::Toplevel,
+};
+
+use super::zstore::ZPTR_SIZE;
+
+pub(crate) const INPUT_SIZE: usize = ZPTR_SIZE + DIGEST_SIZE;
+pub(crate) const NUM_PUBLIC_VALUES: usize = INPUT_SIZE + ZPTR_SIZE;
+
+/// Returns a `StarkMachine` for the Lurk toplevel, with `lurk_main` as entrypoint
+pub(crate) fn new_machine<C1: Chipset<BabyBear>, C2: Chipset<BabyBear>>(
+    lurk_toplevel: &Toplevel<BabyBear, C1, C2>,
+) -> StarkMachine<BabyBearPoseidon2, LairChip<'_, BabyBear, C1, C2>> {
+    let lurk_main_idx = lurk_toplevel.func_by_name("lurk_main").index;
+    let lurk_main_chip = FuncChip::from_index(lurk_main_idx, lurk_toplevel);
+    StarkMachine::new(
+        BabyBearPoseidon2::new(),
+        build_chip_vector(&lurk_main_chip),
+        NUM_PUBLIC_VALUES,
+    )
+}

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -307,7 +307,7 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 41] = [
     "fail",
 ];
 
-const META_SYMBOLS: [&str; 34] = [
+const META_SYMBOLS: [&str; 36] = [
     "def",
     "defrec",
     "update",
@@ -339,7 +339,9 @@ const META_SYMBOLS: [&str; 34] = [
     "defprotocol",
     "prove-protocol",
     "verify-protocol",
-    "micro-chain-serve",
-    "micro-chain-get",
-    "micro-chain-transition",
+    "microchain-start",
+    "microchain-get-genesis",
+    "microchain-get-state",
+    "microchain-transition",
+    "microchain-verify",
 ];

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -314,11 +314,6 @@ pub(crate) fn builtin_set() -> &'static IndexSet<Symbol, FxBuildHasher> {
 }
 
 impl<F: Field, C: Chipset<F>> ZStore<F, C> {
-    #[inline]
-    pub fn hasher(&self) -> &Hasher<F, C> {
-        &self.hasher
-    }
-
     pub(crate) fn hash3(&mut self, preimg: [F; HASH3_SIZE]) -> [F; DIGEST_SIZE] {
         if let Some(img) = self.hashes3.get(&preimg) {
             return *img;
@@ -690,7 +685,7 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
                     self.memoize_atom_dag(ZPtr { tag, digest: zeros });
                     break;
                 }
-                let preimg = hashes4_inv.get(digest).expect("Hash32 preimg not found");
+                let preimg = hashes4_inv.get(digest).expect("Hash4 preimg not found");
                 let (head, tail) = preimg.split_at(ZPTR_SIZE);
                 let head_digest = &head[DIGEST_SIZE..];
                 let tail_digest = &tail[DIGEST_SIZE..];
@@ -699,7 +694,7 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
                 zptr = ZPtr::from_flat_data(tail);
             },
             Tag::Cons => loop {
-                let preimg = hashes4_inv.get(digest).expect("Hash32 preimg not found");
+                let preimg = hashes4_inv.get(digest).expect("Hash4 preimg not found");
                 let (car, cdr) = preimg.split_at(ZPTR_SIZE);
                 let (car_tag, car_digest) = car.split_at(DIGEST_SIZE);
                 let (cdr_tag, cdr_digest) = cdr.split_at(DIGEST_SIZE);
@@ -715,7 +710,7 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
                 zptr = ZPtr::from_flat_data(cdr);
             },
             Tag::Thunk => {
-                let preimg = hashes3_inv.get(digest).expect("Hash24 preimg not found");
+                let preimg = hashes3_inv.get(digest).expect("Hash3 preimg not found");
                 let (fst, snd_digest) = preimg.split_at(ZPTR_SIZE);
                 let (fst_tag, fst_digest) = fst.split_at(DIGEST_SIZE);
                 let fst_tag = Tag::from_field(&fst_tag[0]);
@@ -729,7 +724,7 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
                     self.memoize_atom_dag(ZPtr { tag, digest: zeros });
                     break;
                 }
-                let preimg = hashes5_inv.get(digest).expect("Hash40 preimg not found");
+                let preimg = hashes5_inv.get(digest).expect("Hash5 preimg not found");
                 let (var, rst) = preimg.split_at(ZPTR_SIZE);
                 let (val, env_digest) = rst.split_at(ZPTR_SIZE);
                 let (var_tag, var_digest) = var.split_at(DIGEST_SIZE);
@@ -742,12 +737,12 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
                 memoize_compact110!(var_tag, var_digest, val_tag, val_digest, env_tag, env_digest);
                 digest = env_digest;
                 zptr = ZPtr {
-                    tag: Tag::Env,
+                    tag: env_tag,
                     digest: into_sized(env_digest),
                 };
             },
             Tag::Fun => {
-                let preimg = hashes5_inv.get(digest).expect("Hash40 preimg not found");
+                let preimg = hashes5_inv.get(digest).expect("Hash5 preimg not found");
                 let (args, rest) = preimg.split_at(ZPTR_SIZE);
                 let (body, env_digest) = rest.split_at(ZPTR_SIZE);
                 let (args_tag, args_digest) = args.split_at(DIGEST_SIZE);


### PR DESCRIPTION
* Make the server completely passive. Instead of a meta command, it's now done via command line: `lurk microchain <addr>`
* Clients can spawn new microchains and get an ID back
* Clients can retrieve the genesis state by ID
* Clients can fetch the current state by ID
* Clients can provide proofs of state transition by ID
* Clients can verify the entire microchain by ID

Extra:
* Fix old hole in the DAG by memoizing the DAG of the current env before calling `intern_env`