### PR TITLE
No need for `collect_bindings_as_an_env`

### DIFF
--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -192,7 +192,7 @@ ledger2
 
 ;; Now we can open the committed ledger transfer function on a transaction.
 
-!(call #0x6213c7c9bc4c135227d2a2ff2db25c50985c10b9862f81f321e16acd4ad561 '(1 0 2))
+!(call #0x1100ab79cf026f929a0f4a8edaa34a3cbffba663902deb483a98bc9698b471 '(1 0 2))
 
 ;; And the record reflects that Church sent one unit to Satoshi.
 
@@ -202,7 +202,7 @@ ledger2
 
 ;; We can verify the proof..
 
-!(verify "2e32da01f8c7799915652df4cf50d8b287ae8b42783305b8d61b8b505a2031")
+!(verify "3ec2be088404f2c65da6a7f8d9c48d7acadf902462fe55d8c0683a9bfc88be")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -219,24 +219,24 @@ ledger2
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(chain #0x69b8f3e2e4a5583dd2f9304f8b89aca6bd68962cdf0402ecd688f16d7ae320 '(1 0 2))
+!(chain #0x55e9e42540b3915fcd357bac7fb5ad5e6f299cd9619e11d44a95a26fa41aa '(1 0 2))
 
 !(prove)
 
-!(verify "5c88eb57ef6bc2cf03e0992b76dbc259af3a443a095a581879ba3ecee77ca3")
+!(verify "45e9ae74bd1c72778da7985f55a096b4f2c772eec3d00a78b051e69c0b351d")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(chain #0x900311240aa810b146665f424ae325fa0226c8dcb51a1c2a43abb479fa67e6 '(5 0 2))
+!(chain #0x6018ec368c1130fa5ed4777a33de94e21b0ab4964ea8d3718bfff44b51eb3e '(5 0 2))
 
 !(prove)
 
-!(verify "3b9aa34fca22167d71071da509ab07ad44da80763805bb643d86a1a4f9194f")
+!(verify "49ecca3674d380af21c617e714866e334acc144989632a7ccd244295a64628")
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(chain #0x4667c5ca173b8e211f2b04dbf8120d95afa7fed26c91ad772a33cccd9f560b '(20 1 0))
+!(chain #0x8a0964dc644afdecdee4fa6687e55744290a591e6d1c0468f1fffba4c5059c '(20 1 0))
 
 !(prove)
 
-!(verify "536aaeba3a0764051dd19c1ffba6a072fa6dac4c51eed5af473f5669c2113e")
+!(verify "79bc2aa3e3fcc71ee28a1e0b05c507a4ccb72a4e7158194b80ec96522bc63f")

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -9,7 +9,7 @@
 
 ;; We chain a next commitment by applying the committed function to a value of 9.
 
-!(chain #0x545e921e6ef944cd72811575b1064f8737d520cd04dd75a47ad6c5bf509ea7 9)
+!(chain #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591 9)
 
 ;; The new counter value is 9, and the function returns a new functional commitment.
 
@@ -21,11 +21,11 @@
 
 ;; We can verify the proof.
 
-!(verify "728e57b72d7d05e5356f8fb218fa26f053e8851f4cbf7372c9441460496b21")
+!(verify "11207b18c7ff19e5453f44c56c524afd68286e2d11e1bc279d72481da32e1")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
-!(chain #0x360823fcaffc682078bccb4b38e24620faf4255866f771f5371e3f28dac21d 12)
+!(chain #0x47a1841934c42377e67725038c71987faea4d67eecc704923502f9c0e5754a 12)
 
 ;; Now the counter is 21, and we have a new head commitment.
 
@@ -35,11 +35,11 @@
 
 ;; And verify.
 
-!(verify "3415622ca92481bae4e55ba49b44ab53987064f4cbfcb51805a1bce14d2f88")
+!(verify "61948c697ea4756c4f4c6f47d44af1e4f7174a94e16f6fac3f4e84d13ec65a")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
-!(chain #0x6cd6765d9d15e7f771b4a10adedf32bbf5fbe35f8815f9d8bd6a6b9a485987 14)
+!(chain #0x5d5b7127c8013ab1c8bd602623e96973ea20626053f60d8c21ba07757d1344 14)
 
 ;; 21 + 14 = 35, as expected.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "65dbb2b7a29e01514ccf4463826c4c799c101ed60ffd89f2b5f83706a9e00e")
+!(verify "4f2554b0723e723c82fda0b00368bc676f961b0024085b0b74822317a6c513")
 
 ;; Repeat indefinitely.
 

--- a/src/lurk/cli/tests/first.lurk
+++ b/src/lurk/cli/tests/first.lurk
@@ -43,9 +43,9 @@
                        (let ((counter (+ counter x)))
                          (cons counter (commit (add counter)))))))
                (add 0))))
-!(chain #0x545e921e6ef944cd72811575b1064f8737d520cd04dd75a47ad6c5bf509ea7 1)
+!(chain #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591 1)
 
-!(def state0 (cons nil (comm #0x545e921e6ef944cd72811575b1064f8737d520cd04dd75a47ad6c5bf509ea7)))
+!(def state0 (cons nil (comm #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591)))
 !(transition state1 state0 1)
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))
@@ -59,7 +59,7 @@
                          (cons counter (bignum (commit (add counter))))))))
                (add 0))))
 
-!(def state0 (cons nil #0x959a785bbf1036b70f9a3efd6d3f686ec71926752f7e9b14d3ff020b269869))
+!(def state0 (cons nil #0x446f7ccf9698cd19b7b1aa3e08f7a2746a080e205612292ed0405dcb144420))
 !(transition state1 state0 1)
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))

--- a/src/lurk/cli/tests/second.lurk
+++ b/src/lurk/cli/tests/second.lurk
@@ -8,10 +8,10 @@
 
 ;; test call/chain
 !(call #0x275439f3606672312cd1fd9caf95cfd5bc05c6b8d224819e2e8ea1a6c5808 0)
-!(chain #0x545e921e6ef944cd72811575b1064f8737d520cd04dd75a47ad6c5bf509ea7 1)
+!(chain #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591 1)
 
 ;; test transition
-!(def state (cons nil #0x545e921e6ef944cd72811575b1064f8737d520cd04dd75a47ad6c5bf509ea7))
+!(def state (cons nil #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591))
 !(transition state1 state 1)
 !(assert-eq (car state1) 1)
 

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -106,7 +106,7 @@ impl<F> SymbolsDigests<F> {
 fn native_lurk_funcs<F: PrimeField32>(
     digests: &SymbolsDigests<F>,
     coroutines: &FxIndexMap<Symbol, Coroutine<F>>,
-) -> [FuncE<F>; 38] {
+) -> [FuncE<F>; 37] {
     [
         lurk_main(),
         preallocate_symbols(digests),
@@ -128,7 +128,6 @@ fn native_lurk_funcs<F: PrimeField32>(
         car_cdr(digests),
         eval_let(),
         eval_letrec(),
-        collect_bindings_as_an_env(),
         extend_env_with_mutuals(),
         eval_env_vals(),
         apply(digests),
@@ -590,16 +589,7 @@ pub fn ingress<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                     let ptr = store(fst_tag, fst_ptr, snd_tag, snd_ptr);
                     return (tag, ptr)
                 }
-                Tag::Thunk => {
-                    let (fst_tag_full: [8], fst_digest: [8], snd_digest: [8], trd_digest: [8]) = preimg(hash4, digest);
-                    let env_tag = Tag::Env;
-                    let (fst_tag, fst_ptr) = call(ingress, fst_tag_full, fst_digest);
-                    let (_snd_tag, snd_ptr) = call(ingress, env_tag, zeros, snd_digest);
-                    let (_trd_tag, trd_ptr) = call(ingress, env_tag, zeros, trd_digest);
-                    let ptr = store(fst_tag, fst_ptr, snd_ptr, trd_ptr);
-                    return (tag, ptr)
-                }
-                Tag::Fun => {
+                Tag::Fun, Tag::Thunk => {
                     let (args_tag_full: [8], args_digest: [8],
                          body_tag_full: [8], body_digest: [8],
                                              env_digest:  [8]) = preimg(hash5, digest);
@@ -683,19 +673,7 @@ pub fn egress<F: AbstractField>(digests: &SymbolsDigests<F>) -> FuncE<F> {
                     let digest: [8] = call(hash4, fst_tag_full, fst_digest, snd_tag_full, snd_digest);
                     return (tag, digest)
                 }
-                Tag::Thunk => {
-                    let (fst_tag, fst_ptr, snd_ptr, trd_ptr) = load(val);
-                    let env_tag = Tag::Env;
-                    let (fst_tag, fst_digest: [8]) = call(egress, fst_tag, fst_ptr);
-                    let (_snd_tag, snd_digest: [8]) = call(egress, env_tag, snd_ptr);
-                    let (_trd_tag, trd_digest: [8]) = call(egress, env_tag, trd_ptr);
-
-                    let padding = [0; 7];
-                    let fst_tag_full: [8] = (fst_tag, padding);
-                    let digest: [8] = call(hash4, fst_tag_full, fst_digest, snd_digest, trd_digest);
-                    return (tag, digest)
-                }
-                Tag::Fun => {
+                Tag::Fun, Tag::Thunk => {
                     let (args_tag, args_ptr, body_tag, body_ptr, env_ptr) = load(val);
                     let (args_tag, args_digest: [8]) = call(egress, args_tag, args_ptr);
                     let (body_tag, body_digest: [8]) = call(egress, body_tag, body_ptr);
@@ -863,9 +841,10 @@ pub fn eval<F: AbstractField>() -> FuncE<F> {
                     let (res_tag, res) = call(env_lookup, expr_tag, expr_digest, env);
                     match res_tag {
                         Tag::Thunk => {
-                            let (body_tag, body, mutual_env, body_env) = load(res);
+                            let (body_tag, body, binds_tag, binds, mutual_env) = load(res);
                             // extend `body_env` with the bindings from `mutual_env`, with thunked values
-                            let ext_env = call(extend_env_with_mutuals, mutual_env, mutual_env, body_env, body_env);
+                            // IMPORTANT: at this point this operation cannot return an error
+                            let (_tag, ext_env) = call(extend_env_with_mutuals, binds_tag, binds, binds, mutual_env);
                             let (res_tag, res) = call(eval, body_tag, body, ext_env);
                             return (res_tag, res)
                         }
@@ -1431,18 +1410,7 @@ pub fn equal_inner<F: AbstractField>() -> FuncE<F> {
                     let eq = mul(fst_eq, snd_eq);
                     return eq
                 }
-                Tag::Thunk => {
-                    let env_tag = Tag::Env;
-                    let (a_fst: [2], a_snd, a_trd) = load(a);
-                    let (b_fst: [2], b_snd, b_trd) = load(b);
-                    let fst_eq = call(equal_inner, a_fst, b_fst);
-                    let snd_eq = call(equal_inner, env_tag, a_snd, env_tag, b_snd);
-                    let trd_eq = call(equal_inner, env_tag, a_trd, env_tag, b_trd);
-                    let eq = mul(fst_eq, snd_eq);
-                    let eq = mul(eq, trd_eq);
-                    return eq
-                }
-                Tag::Fun => {
+                Tag::Fun, Tag::Thunk => {
                     let trd_tag = Tag::Env;
                     let (a_fst: [2], a_snd: [2], a_trd) = load(a);
                     let (b_fst: [2], b_snd: [2], b_trd) = load(b);
@@ -2027,72 +1995,56 @@ pub fn eval_let<F: AbstractField>() -> FuncE<F> {
     )
 }
 
-/// Tries to collect the bindings from a `letrec` (or `let`) expression. The bindings
-/// are turned into an environment for succinctness.
-/// In case of success, return `(1, collected_env)`. If an error `err` is found,
-/// return `(0, err)` instead.
-pub fn collect_bindings_as_an_env<F: AbstractField>() -> FuncE<F> {
-    func!(
-        fn collect_bindings_as_an_env(binds_tag, binds): [2] {
-            let zero = 0;
-            let invalid_form_err = EvalErr::InvalidForm;
-            match binds_tag {
-                InternalTag::Nil => {
-                    let one = 1;
-                    return (one, zero)
-                }
-                Tag::Cons => {
-                    let cons_tag = Tag::Cons;
-                    let (binding_tag, binding, binds_tag, binds) = load(binds);
-                    let (success, tail_env) = call(collect_bindings_as_an_env, binds_tag, binds);
-                    if !success {
-                        return (zero, invalid_form_err)
-                    }
-                    let binding_not_cons = sub(binding_tag, cons_tag);
-                    if binding_not_cons {
-                        return (zero, invalid_form_err)
-                    }
-                    let (var_tag, var, rest_tag, rest) = load(binding);
-                    match var_tag {
-                        Tag::Sym, Tag::Builtin, Tag::Coroutine => {
-                            let rest_tag_not_cons = sub(rest_tag, cons_tag);
-                            if rest_tag_not_cons {
-                                return (zero, invalid_form_err)
-                            }
-                            let (val_tag, val, rest_tag, _rest) = load(rest);
-                            let nil_tag = InternalTag::Nil;
-                            let rest_tag_not_nil = sub(rest_tag, nil_tag);
-                            if rest_tag_not_nil {
-                                return (zero, invalid_form_err)
-                            }
-                            let one = 1;
-                            let env = store(var_tag, var, val_tag, val, tail_env);
-                            return (one, env)
-                        }
-                    };
-                    let illegal_binding_var_err = EvalErr::IllegalBindingVar;
-                    return (zero, illegal_binding_var_err)
-                }
-            };
-            return (zero, invalid_form_err)
-        }
-    )
-}
-
 /// Extends `extended_env` with the bindings from `consumed_env` such that the bound values
 /// are turned into thunks that hold `mutual_env` and `body_env`
 pub fn extend_env_with_mutuals<F: AbstractField>() -> FuncE<F> {
     func!(
-        fn extend_env_with_mutuals(consumed_env, mutual_env, body_env, extended_env): [1] {
-            if !consumed_env {
-                return extended_env
-            }
-            let (var_tag, var, val_tag, val, consumed_env) = load(consumed_env);
-            let constructed_env = call(extend_env_with_mutuals, consumed_env, mutual_env, body_env, extended_env);
-            let mutual_thunk_tag = Tag::Thunk;
-            let mutual_thunk = store(val_tag, val, mutual_env, body_env);
-            let extended_constructed_env = store(var_tag, var, mutual_thunk_tag, mutual_thunk, constructed_env);
-            return extended_constructed_env
+        fn extend_env_with_mutuals(binds_tag, binds, mutual_binds, mutual_env): [2] {
+            let err_tag = Tag::Err;
+            let env_tag = Tag::Env;
+            let invalid_form_err = EvalErr::InvalidForm;
+            match binds_tag {
+                InternalTag::Nil => {
+                    return (env_tag, mutual_env)
+                }
+                Tag::Cons => {
+                    let cons_tag = Tag::Cons;
+                    let (binding_tag, binding, binds_tag, binds) = load(binds);
+                    let binding_not_cons = sub(binding_tag, cons_tag);
+                    if binding_not_cons {
+                        return (err_tag, invalid_form_err)
+                    }
+                    let (var_tag, var, rest_tag, rest) = load(binding);
+                    let rest_tag_not_cons = sub(rest_tag, cons_tag);
+                    if rest_tag_not_cons {
+                        return (err_tag, invalid_form_err)
+                    }
+                    let (expr_tag, expr, rest_tag, _rest) = load(rest);
+                    let nil_tag = InternalTag::Nil;
+                    let rest_tag_not_nil = sub(rest_tag, nil_tag);
+                    if rest_tag_not_nil {
+                        return (err_tag, invalid_form_err)
+                    }
+                    match var_tag {
+                        Tag::Sym, Tag::Builtin, Tag::Coroutine => {
+                            let (ext_env_tag, ext_env) = call(extend_env_with_mutuals, binds_tag, binds, mutual_binds, mutual_env);
+                            match ext_env_tag {
+                                Tag::Err => {
+                                    return (ext_env_tag, ext_env)
+                                }
+                            };
+                            let thunk_tag = Tag::Thunk;
+                            // IMPORTANT: At this point, `mutual_binds` must be a cons
+                            let thunk = store(expr_tag, expr, cons_tag, mutual_binds, mutual_env);
+                            let res_env = store(var_tag, var, thunk_tag, thunk, ext_env);
+                            return (env_tag, res_env)
+                        }
+                    };
+                    let illegal_binding_var_err = EvalErr::IllegalBindingVar;
+                    return (err_tag, illegal_binding_var_err)
+                }
+            };
+            return (err_tag, invalid_form_err)
         }
     )
 }
@@ -2102,19 +2054,20 @@ pub fn extend_env_with_mutuals<F: AbstractField>() -> FuncE<F> {
 /// `(Tag::Err, err)` instead.
 pub fn eval_env_vals<F: AbstractField>() -> FuncE<F> {
     func!(
-        partial fn eval_env_vals(env_to_evaluate, env): [2] {
-            if !env_to_evaluate {
+        partial fn eval_env_vals(env, ext_env): [2] {
+            let not_eq = sub(ext_env, env);
+            if !not_eq {
                 let env_tag = Tag::Env;
                 return (env_tag, env)
             }
-            let (_var_tag, _var, val_tag, val, env_to_evaluate) = load(env_to_evaluate);
+            let (_var_tag, _var, val_tag, val, ext_env) = load(ext_env);
             let (res_tag, res) = call(eval, val_tag, val, env);
             match res_tag {
                 Tag::Err => {
                     return (res_tag, res)
                 }
             };
-            let (res_tag, res) = call(eval_env_vals, env_to_evaluate, env);
+            let (res_tag, res) = call(eval_env_vals, env, ext_env);
             return (res_tag, res)
         }
     )
@@ -2123,16 +2076,15 @@ pub fn eval_env_vals<F: AbstractField>() -> FuncE<F> {
 pub fn eval_letrec<F: AbstractField>() -> FuncE<F> {
     func!(
         partial fn eval_letrec(binds_tag, binds, body_tag, body, env): [2] {
-            // collect the mutual env
-            let (success, mutual_env_or_err) = call(collect_bindings_as_an_env, binds_tag, binds);
-            if !success {
-                let err_tag = Tag::Err;
-                return (err_tag, mutual_env_or_err)
-            }
             // extend `env` with the bindings from the mutual env, but with thunked values
-            let ext_env = call(extend_env_with_mutuals, mutual_env_or_err, mutual_env_or_err, env, env);
+            let (ext_env_tag, ext_env) = call(extend_env_with_mutuals, binds_tag, binds, binds, env);
+            match ext_env_tag {
+                Tag::Err => {
+                    return (ext_env_tag, ext_env)
+                }
+            };
             // preemptively evaluate each binding value for side-effects, error detection and memoization
-            let (res_tag, res) = call(eval_env_vals, mutual_env_or_err, ext_env);
+            let (res_tag, res) = call(eval_env_vals, env, ext_env);
             match res_tag {
                 Tag::Err => {
                     return (res_tag, res)
@@ -2366,8 +2318,6 @@ mod test {
         let eval_list = FuncChip::from_name("eval_list", toplevel);
         let eval_let = FuncChip::from_name("eval_let", toplevel);
         let eval_letrec = FuncChip::from_name("eval_letrec", toplevel);
-        let collect_bindings_as_an_env =
-            FuncChip::from_name("collect_bindings_as_an_env", toplevel);
         let extend_env_with_mutuals = FuncChip::from_name("extend_env_with_mutuals", toplevel);
         let eval_env_vals = FuncChip::from_name("eval_env_vals", toplevel);
         let coerce_if_sym = FuncChip::from_name("coerce_if_sym", toplevel);
@@ -2408,19 +2358,18 @@ mod test {
         expect_eq(eval_begin.width(), expect!["68"]);
         expect_eq(eval_list.width(), expect!["72"]);
         expect_eq(eval_let.width(), expect!["94"]);
-        expect_eq(eval_letrec.width(), expect!["70"]);
-        expect_eq(collect_bindings_as_an_env.width(), expect!["48"]);
-        expect_eq(extend_env_with_mutuals.width(), expect!["31"]);
+        expect_eq(eval_letrec.width(), expect!["66"]);
+        expect_eq(extend_env_with_mutuals.width(), expect!["54"]);
         expect_eq(eval_env_vals.width(), expect!["66"]);
         expect_eq(coerce_if_sym.width(), expect!["9"]);
         expect_eq(open_comm.width(), expect!["50"]);
         expect_eq(equal.width(), expect!["86"]);
-        expect_eq(equal_inner.width(), expect!["59"]);
+        expect_eq(equal_inner.width(), expect!["58"]);
         expect_eq(car_cdr.width(), expect!["61"]);
         expect_eq(apply.width(), expect!["114"]);
         expect_eq(env_lookup.width(), expect!["52"]);
-        expect_eq(ingress.width(), expect!["105"]);
-        expect_eq(egress.width(), expect!["82"]);
+        expect_eq(ingress.width(), expect!["104"]);
+        expect_eq(egress.width(), expect!["81"]);
         expect_eq(hash3.width(), expect!["493"]);
         expect_eq(hash4.width(), expect!["655"]);
         expect_eq(hash5.width(), expect!["815"]);

--- a/src/lurk/tests/eval.rs
+++ b/src/lurk/tests/eval.rs
@@ -299,8 +299,8 @@ test_raw!(
     |z| {
         let eq = z.intern_symbol_no_lang(&builtin_sym("eq"));
         let env = z.intern_empty_env();
-        let arg1 = z.intern_thunk(*z.t(), env, env);
-        let arg2 = z.intern_thunk(*z.t(), env, env);
+        let arg1 = z.intern_thunk(*z.t(), *z.nil(), env);
+        let arg2 = z.intern_thunk(*z.t(), *z.nil(), env);
         z.intern_list([eq, arg1, arg2])
     },
     |z| *z.t()


### PR DESCRIPTION
There's no need to convert the bindings to an efficient form because we always extend the same environment, so the extension is only done once (the rest is memoized)