### PR TITLE
feat: composable meta commands

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -53,7 +53,7 @@ fn setup<C: Chipset<BabyBear>>(
 ) {
     let code = build_lurk_expr(arg);
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag, digest } = zstore.read(&code, &Default::default()).unwrap();
+    let ZPtr { tag, digest } = zstore.read(&code, &Default::default());
 
     let mut record = QueryRecord::new(toplevel);
     record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -57,7 +57,7 @@ fn setup<'a, C: Chipset<BabyBear>>(
 ) {
     let code = build_lurk_expr(a, b);
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag, digest } = zstore.read(&code, &Default::default()).unwrap();
+    let ZPtr { tag, digest } = zstore.read(&code, &Default::default());
 
     let mut record = QueryRecord::new(toplevel);
     record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -58,7 +58,7 @@ fn setup<C: Chipset<BabyBear>>(
     let code = build_lurk_expr(n);
 
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag, digest } = zstore.read(&code, &Default::default()).unwrap();
+    let ZPtr { tag, digest } = zstore.read(&code, &Default::default());
 
     let mut record = QueryRecord::new(toplevel);
     record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);

--- a/demo/mastermind.lurk
+++ b/demo/mastermind.lurk
@@ -165,41 +165,41 @@
 !(def regression (init-game (hide #0x99887766 '(4 2 2 3)) (hide #0x1234 '(3 1 4 1)) 4 6 20))
 !(assert-eq :player-1-to-guess (car regression))
 
-!(transition regression1 regression '(1 1 1 1))
+!(defq regression1 !(transition regression '(1 1 1 1)))
 !(assert-eq :player-2-to-guess (car regression1))
 
-!(transition regression2 regression1 '(1 1 1 1))
+!(defq regression2 !(transition regression1 '(1 1 1 1)))
 !(assert-eq '(:player-1-to-guess 2 . 0) (car regression2))
 
-!(transition regression3 regression2 '(1 1 2 2))
+!(defq regression3 !(transition regression2 '(1 1 2 2)))
 !(assert-eq '(:player-2-to-guess 0 . 0) (car regression3))
 
-!(transition regression4 regression3 '(2 1 1 1))
+!(defq regression4 !(transition regression3 '(2 1 1 1)))
 !(assert-eq '(:player-1-to-guess 1 . 1) (car regression4))
 
-!(transition regression5 regression4 '(1 1 3 3))
+!(defq regression5 !(transition regression4 '(1 1 3 3)))
 !(assert-eq '(:player-2-to-guess 0 . 1) (car regression5))
 
-!(transition regression6 regression5 '(1 2 3 4))
+!(defq regression6 !(transition regression5 '(1 2 3 4)))
 
 ;; Player 1 supplies a bad code. Player 2 supplies a good code.
 !(def bad1 (init-game (commit '(1)) (commit '(6 6 6 5)) 4 6 7))
 
-!(transition bad1a bad1 '(1 1 1 1))
+!(defq bad1a !(transition bad1 '(1 1 1 1)))
 !(assert-eq :player-1-bad-code (car bad1a))
 
 ;; Player 2 just calls the continuation with zero args, to prove own code length is correct (or not).
-!(transition bad1b bad1a)
+!(defq bad1b !(transition bad1a))
 ;; As expected, player 2 wins.
 !(assert-eq :winner-2 (car bad1b))
 
 ;; Both players supply bad codes.
 !(def bad2 (init-game (commit '(1)) (commit '(6 6)) 4 6 7))
 
-!(transition bad2a bad2 '(1 1 1 1))
+!(defq bad2a !(transition bad2 '(1 1 1 1)))
 !(assert-eq :player-1-bad-code (car bad2a))
 
-!(transition bad2b bad2a)
+!(defq bad2b !(transition bad2a))
 ;; As expected, it is a draw.
 !(assert-eq :draw (car bad2b))
 
@@ -212,15 +212,15 @@
 
 ;; ;; Player 1 has the advantage and has already guessed correctly, so no next guess is needed.
 ;; ;; This transition is just to determine whether Player 2 already (previously) guessed correctly.
-!(transition mA m0 '(6 6 6 5))
+!(defq mA !(transition m0 '(6 6 6 5)))
 ;(emit (cons :mA (car mA)))
 !(assert-eq :player-2-to-guess (car mA))
 
-!(transition mB mA '(1 1 1 1))
+!(defq mB !(transition mA '(1 1 1 1)))
 ;(emit (cons :mB (car mB)))
 !(assert-eq :advantage-1 (car mB))
 
-!(transition mC mB)
+!(defq mC !(transition mB))
 ;(emit (cons :mC (car mC)))
 !(assert-eq :winner-1 (car mC))
 
@@ -228,11 +228,11 @@
 !(assert-eq nil (cdr mC))
 
 ;; Rewind and let player 2 nullify the advantage.
-!(transition mB2 mA '(1 2 3 4))
+!(defq mB2 !(transition mA '(1 2 3 4)))
 ;(emit (cons :mB2 mB2))
 !(assert-eq :advantage-1 (car mB2))
 
-!(transition mC2 mB2)
+!(defq mC2 !(transition mB2))
 ;(emit (cons :mC2 mC2))
 !(assert-eq :draw (car mC2))
 
@@ -241,24 +241,24 @@
 
 
 ;; Rewind and try a different ending.
-!(transition m1 m0 '(5 5 5 5)) ; player 1 guess, round 1
+!(defq m1 !(transition m0 '(5 5 5 5))) ; player 1 guess, round 1
 
 ;(emit (cons :m1 (car m1)))
 !(assert-eq :player-2-to-guess (car m1))
 
-!(transition m2 m1 '(1 2 4 3)) ; player 2 guess, round 1
+!(defq m2 !(transition m1 '(1 2 4 3))) ; player 2 guess, round 1
 ;(emit (cons :m2 (car m2)))
 !(assert-eq '(:player-1-to-guess 1 . 0) (car m2)) ; guess (5 5 5 5), code (6 6 6 5)
 
-!(transition m3 m2 '(5 5 5 5)) ; player 1 guess, round 2
+!(defq m3 !(transition m2 '(5 5 5 5))) ; player 1 guess, round 2
 ;(emit (cons :m3 (car m3)))
 !(assert-eq '(:player-2-to-guess 2 . 2) (car m3)) ; guess (1 2 4 3), code (1 2 3 4)
 
-!(transition m4 m3 '(1 2 3 4)) ; player 2 guess, round 2
+!(defq m4 !(transition m3 '(1 2 3 4))) ; player 2 guess, round 2
 ;(emit (cons :m4 (car m4)))
 !(assert-eq '(:player-1-to-guess 1 . 0) (car m4)) ; guess (1 2 3 4), code (1 2 3 4)
 
-!(transition m5 m4 '(6 6 6 5)) ; player 1 guess, round 3
+!(defq m5 !(transition m4 '(6 6 6 5))) ; player 1 guess, round 3
 ;(emit (cons :m5 (car m5)))
 !(assert-eq :winner-2 (car m5))
 
@@ -267,13 +267,13 @@
 
 ;; TODO: test other possible continuations of the game to exercise other outcomes.
 
-!(transition m4x m3 '(1 1 1 1)) ; player 2 guess, round 2
+!(defq m4x !(transition m3 '(1 1 1 1))) ; player 2 guess, round 2
 ;(emit (cons :m4x (car m4x)))
-!(transition m5x m4x '(2 2 2 2)) ; player 1 guess, round 3
+!(defq m5x !(transition m4x '(2 2 2 2))) ; player 1 guess, round 3
 ;(emit (cons :m5x m5x))
-!(transition m6x m5x '(3 3 3 3)) ; player 2 guess, round 3
+!(defq m6x !(transition m5x '(3 3 3 3))) ; player 2 guess, round 3
 ;(emit (cons :m6x m6x))
-!(transition m7x m6x '(4 4 4 4))
+!(defq m7x !(transition m6x '(4 4 4 4)))
 !(assert-eq :draw-max (car m7x))
 
 ;; Chain has terminated.

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -575,7 +575,7 @@ mod test {
     }
 
     fn read_wideptr(zstore: &mut ZStore<BabyBear, LurkChip>, src: &str) -> WidePtr {
-        let ZPtr { tag, digest } = zstore.read(src, &Default::default()).unwrap();
+        let ZPtr { tag, digest } = zstore.read(src, &Default::default());
         wide_ptr(tag.elt(), digest)
     }
 
@@ -636,9 +636,7 @@ mod test {
 
         // Determine whether we want to use the intended in/out, or attack the program with the bad in/out
         if let Some((bad_input, bad_output)) = bad_input_output {
-            let bad_zptr = zstore
-                .read(bad_input, &Default::default())
-                .expect("failed to read");
+            let bad_zptr = zstore.read(bad_input, &Default::default());
             let bad_input = store.zptr_ptr(&bad_zptr).unwrap();
             let bad_output = vec![(read_wideptr(&mut zstore, bad_output),)];
 

--- a/src/loam/distilled_evaluation.rs
+++ b/src/loam/distilled_evaluation.rs
@@ -1040,7 +1040,7 @@ mod test {
     }
 
     fn read_wideptr(zstore: &mut ZStore<BabyBear, LurkChip>, src: &str) -> WidePtr {
-        let ZPtr { tag, digest } = zstore.read(src, &Default::default()).unwrap();
+        let ZPtr { tag, digest } = zstore.read(src, &Default::default());
         wide_ptr(tag.elt(), digest)
     }
 

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -1232,7 +1232,7 @@ mod test {
     }
 
     fn read_wideptr(zstore: &mut ZStore<BabyBear, LurkChip>, src: &str) -> WidePtr {
-        let ZPtr { tag, digest } = zstore.read(src, &Default::default()).unwrap();
+        let ZPtr { tag, digest } = zstore.read(src, &Default::default());
         wide_ptr(tag.elt(), digest)
     }
 
@@ -1391,8 +1391,8 @@ mod test {
     #[test]
     fn test_lambda() {
         let mut zstore = lurk_zstore();
-        let args = zstore.read("(x)", &Default::default()).unwrap();
-        let body = zstore.read("(+ x 1)", &Default::default()).unwrap();
+        let args = zstore.read("(x)", &Default::default());
+        let body = zstore.read("(+ x 1)", &Default::default());
         let env = *zstore.nil();
 
         let fun = zstore.intern_fun(args, body, env);

--- a/src/lurk/cli/tests/first.lurk
+++ b/src/lurk/cli/tests/first.lurk
@@ -46,10 +46,10 @@
 !(chain #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591 1)
 
 !(def state0 (cons nil (comm #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591)))
-!(transition state1 state0 1)
+!(defq state1 !(transition state0 1))
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))
-!(transition state2 state1 4)
+!(defq state2 !(transition state1 4))
 !(assert-eq (car state2) 5)
 !(fetch (cdr state2))
 
@@ -60,10 +60,10 @@
                (add 0))))
 
 !(def state0 (cons nil #0x446f7ccf9698cd19b7b1aa3e08f7a2746a080e205612292ed0405dcb144420))
-!(transition state1 state0 1)
+!(defq state1 !(transition state0 1))
 !(assert-eq (car state1) 1)
 !(fetch (cdr state1))
-!(transition state2 state1 4)
+!(defq state2 !(transition state1 4))
 !(assert-eq (car state2) 5)
 !(fetch (cdr state2))
 
@@ -78,5 +78,5 @@
 
 ;; test dump-expr/load-expr
 !(dump-expr (+ 1 1) "repl-test-two")
-!(load-expr two "repl-test-two")
+!(defq two !(load-expr "repl-test-two"))
 !(assert-eq two 2)

--- a/src/lurk/cli/tests/second.lurk
+++ b/src/lurk/cli/tests/second.lurk
@@ -12,8 +12,8 @@
 
 ;; test transition
 !(def state (cons nil #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591))
-!(transition state1 state 1)
+!(defq state1 !(transition state 1))
 !(assert-eq (car state1) 1)
 
-!(load-expr two "repl-test-two")
+!(defq two !(load-expr "repl-test-two"))
 !(assert-eq two 2)

--- a/src/lurk/cli/tests/verify.lurk
+++ b/src/lurk/cli/tests/verify.lurk
@@ -1,5 +1,5 @@
 !(inspect "3d8fad22afdde5643d55e9eaae4537bfc6d610c6b1bdf4c913560576cbe327")
 !(verify "3d8fad22afdde5643d55e9eaae4537bfc6d610c6b1bdf4c913560576cbe327")
 
-!(load-expr my-protocol "repl-test-protocol")
+!(defq my-protocol !(load-expr "repl-test-protocol"))
 !(verify-protocol my-protocol "repl-test-protocol-proof")

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -2392,9 +2392,7 @@ mod test {
 
         let assert_ingress_egress_correctness = |code| {
             let zstore = &mut zstore.clone();
-            let ZPtr { tag, digest } = zstore
-                .read_with_state(state.clone(), code, lang_symbols)
-                .unwrap();
+            let ZPtr { tag, digest } = zstore.read_with_state(code, state.clone(), lang_symbols);
             let tag = tag.to_field();
 
             let digest: List<_> = digest.into();

--- a/src/lurk/parser/base.rs
+++ b/src/lurk/parser/base.rs
@@ -30,7 +30,7 @@ impl Default for LitBase {
 }
 
 impl LitBase {
-    pub fn parse_code<F>(i: Span<'_>) -> ParseResult<'_, F, Self> {
+    pub fn parse_code(i: Span<'_>) -> ParseResult<'_, Self> {
         alt((
             value(Self::Bin, tag("b")),
             value(Self::Oct, tag("o")),
@@ -76,7 +76,7 @@ impl LitBase {
         base_x::encode(self.base_digits(), input.as_ref())
     }
 
-    pub fn decode<'a, F>(&self, input: Span<'a>) -> ParseResult<'a, F, Vec<u8>> {
+    pub fn decode<'a>(&self, input: Span<'a>) -> ParseResult<'a, Vec<u8>> {
         let (i, o) = input.split_at_position_complete(|x| !self.is_digit(x))?;
         match base_x::decode(self.base_digits(), o.fragment()) {
             Ok(bytes) => Ok((i, bytes)),
@@ -90,7 +90,7 @@ impl LitBase {
 
 macro_rules! define_parse_digits {
     ($name:ident, $base:ident, $digit_str:expr, $digits_str:expr, $map_fn:expr) => {
-        pub fn $name<F>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, String> {
+        pub fn $name() -> impl Fn(Span<'_>) -> ParseResult<'_, String> {
             move |from: Span<'_>| {
                 let (i, d) = context($digit_str, satisfy(|x| LitBase::$base.is_digit(x)))(from)?;
                 let (i, ds) = context(
@@ -131,7 +131,7 @@ define_parse_digits!(
     |x| x.to_ascii_lowercase()
 );
 
-pub fn parse_litbase_code<F>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, LitBase> {
+pub fn parse_litbase_code() -> impl Fn(Span<'_>) -> ParseResult<'_, LitBase> {
     move |from: Span<'_>| {
         map_parse_err(
             alt((
@@ -146,9 +146,7 @@ pub fn parse_litbase_code<F>() -> impl Fn(Span<'_>) -> ParseResult<'_, F, LitBas
 }
 
 #[allow(clippy::type_complexity)]
-pub fn parse_litbase_digits<F>(
-    base: LitBase,
-) -> Box<dyn Fn(Span<'_>) -> ParseResult<'_, F, String>> {
+pub fn parse_litbase_digits(base: LitBase) -> Box<dyn Fn(Span<'_>) -> ParseResult<'_, String>> {
     Box::new(move |from: Span<'_>| match base {
         LitBase::Bin => parse_bin_digits()(from),
         LitBase::Oct => parse_oct_digits()(from),

--- a/src/lurk/parser/mod.rs
+++ b/src/lurk/parser/mod.rs
@@ -7,7 +7,7 @@ pub mod string;
 pub mod syntax;
 
 pub type Span<'a> = nom_locate::LocatedSpan<&'a str>;
-pub type ParseResult<'a, F, T> = nom::IResult<Span<'a>, T, error::ParseError<Span<'a>, F>>;
+pub type ParseResult<'a, T> = nom::IResult<Span<'a>, T, error::ParseError<Span<'a>>>;
 
 // see https://github.com/sg16-unicode/sg16/issues/69
 pub static LURK_WHITESPACE: [char; 27] = [

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -237,6 +237,12 @@ pub fn builtin_sym(name: &str) -> Symbol {
     Symbol::sym(&[LURK_PACKAGE_NAME, BUILTIN_PACKAGE_NAME, name])
 }
 
+/// Returns the symbol in the `.lurk.meta` package given the symbol name
+#[inline]
+pub fn meta_sym(name: &str) -> Symbol {
+    Symbol::sym(&[LURK_PACKAGE_NAME, META_PACKAGE_NAME, name])
+}
+
 /// Returns the symbol corresponding to the name of the meta package
 #[inline]
 pub fn meta_package_symbol() -> Symbol {
@@ -307,8 +313,9 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 41] = [
     "fail",
 ];
 
-const META_SYMBOLS: [&str; 36] = [
+pub(crate) const META_SYMBOLS: [&str; 37] = [
     "def",
+    "defq",
     "defrec",
     "update",
     "load",

--- a/src/lurk/tests/eval.rs
+++ b/src/lurk/tests/eval.rs
@@ -59,9 +59,7 @@ fn test_case_raw(
 fn test_case(input_code: &'static str, expected_cloj: fn(&mut ZStore<F, LurkChip>) -> ZPtr<F>) {
     let (toplevel, zstore, config) = test_setup_data();
     let mut zstore = zstore.clone();
-    let zptr = zstore
-        .read(input_code, &Default::default())
-        .expect("Read failure");
+    let zptr = zstore.read(input_code, &Default::default());
     run_tests(
         &zptr,
         &ZPtr::null(Tag::Env),
@@ -79,9 +77,7 @@ fn test_case_env(
 ) {
     let (toplevel, zstore, config) = test_setup_data();
     let mut zstore = zstore.clone();
-    let zptr = zstore
-        .read(input_code, &Default::default())
-        .expect("Read failure");
+    let zptr = zstore.read(input_code, &Default::default());
     let env = env_cloj(&mut zstore);
     run_tests(
         &zptr,

--- a/src/lurk/tests/lang.rs
+++ b/src/lurk/tests/lang.rs
@@ -147,7 +147,7 @@ fn test_setup_data() -> &'static (
 fn test_case(input_code: &'static str, expected_cloj: fn(&mut ZStore<F, LurkChip>) -> ZPtr<F>) {
     let (lang_symbols, toplevel, zstore, config) = test_setup_data();
     let mut zstore = zstore.clone();
-    let zptr = zstore.read(input_code, lang_symbols).expect("Read failure");
+    let zptr = zstore.read(input_code, lang_symbols);
     run_tests(
         &zptr,
         &ZPtr::null(Tag::Env),

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -55,7 +55,7 @@ fn setup<C: Chipset<BabyBear>>(
 ) {
     let code = build_lurk_expr(arg);
     let zstore = &mut lurk_zstore();
-    let ZPtr { tag, digest } = zstore.read(&code, &Default::default()).unwrap();
+    let ZPtr { tag, digest } = zstore.read(&code, &Default::default());
 
     let mut record = QueryRecord::new(toplevel);
     record.inject_inv_queries("hash4", toplevel, &zstore.hashes4);


### PR DESCRIPTION
Makes it possible to assemble meta commands in Lurk expressions. Each meta command is resolved to the value it returns before evaluating the whole expression with the VM.

Closes #218