### PR TITLE
chore: print returns from meta commands

### DIFF
--- a/src/lurk/cli/tests/first.lurk
+++ b/src/lurk/cli/tests/first.lurk
@@ -48,10 +48,10 @@
 !(def state0 (cons nil (comm #0x64fee21bad514ff18399dfc5066caebf34acc0441c9af675ba95a998077591)))
 !(defq state1 !(transition state0 1))
 !(assert-eq (car state1) 1)
-!(fetch (cdr state1))
+!(open (cdr state1))
 !(defq state2 !(transition state1 4))
 !(assert-eq (car state2) 5)
-!(fetch (cdr state2))
+!(open (cdr state2))
 
 !(clear)
 !(commit (eval '(letrec ((add (lambda (counter x)
@@ -62,10 +62,10 @@
 !(def state0 (cons nil #0x446f7ccf9698cd19b7b1aa3e08f7a2746a080e205612292ed0405dcb144420))
 !(defq state1 !(transition state0 1))
 !(assert-eq (car state1) 1)
-!(fetch (cdr state1))
+!(open (cdr state1))
 !(defq state2 !(transition state1 4))
 !(assert-eq (car state2) 5)
-!(fetch (cdr state2))
+!(open (cdr state2))
 
 ;; test packages
 !(defpackage abc)

--- a/src/lurk/cli/tests/second.lurk
+++ b/src/lurk/cli/tests/second.lurk
@@ -1,5 +1,5 @@
 ;; test fetching data from first.lurk
-!(fetch #0x22b5fa9cf049349a7d0e5fdeef38e865b79e13a9feb29730c845973af08bef)
+!(open #0x22b5fa9cf049349a7d0e5fdeef38e865b79e13a9feb29730c845973af08bef)
 !(assert-eq (open #0x22b5fa9cf049349a7d0e5fdeef38e865b79e13a9feb29730c845973af08bef) 42)
 
 ;; test open

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -313,7 +313,7 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 41] = [
     "fail",
 ];
 
-pub(crate) const META_SYMBOLS: [&str; 38] = [
+pub(crate) const META_SYMBOLS: [&str; 37] = [
     "def",
     "defq",
     "defrec",
@@ -327,7 +327,6 @@ pub(crate) const META_SYMBOLS: [&str; 38] = [
     "hide",
     "rand",
     "commit",
-    "fetch",
     "open",
     "clear",
     "set-env",


### PR DESCRIPTION
* Remove printing side effects that should be handled from outside
* Drop the `fetch` meta command as `open` can do the job