### PR TITLE
Microbank

### DIFF
--- a/demo/microbank.lurk
+++ b/demo/microbank.lurk
@@ -1,0 +1,218 @@
+!(load "../lib/lib.lurk")
+
+!(def help-message '(:help :about :options :state :id :supply :audit (:create-account pub-key) (:balance pub-key) (:grant amount to) (:transfer amount from to)))
+
+!(def make-pub-key (lambda (name secret) (hide secret name)))
+
+!(def derive-account (lambda (bank-id pub-key)
+                       ;; Derive new secret to compartmentalize account from pub-key. Now user does not need access to
+                       ;; his priv-key (i.e. (secret pub-key)) when authenticating to the bank. Rather, it suffices to
+                       ;; prove knowledge of the derived account-secret. The account-secret must be protected, but it
+                       ;; need not be persisted carefully, since it can always be derived again (from the priv-key).
+                       (let ((account-secret (bignum (hide (secret pub-key) bank-id))))
+                         (hide (bignum (hide account-secret bank-id)) pub-key))))
+
+;; Only the account owner can authenticate it.
+!(def authenticate (lambda (account) (open account)))
+
+;; Add account for pub-key, unless account already exists.
+!(def maybe-add-account (lambda (account accounts)
+                          ;; TODO: Create and use efficient util for this.
+                          (if (getf accounts account)
+                              accounts
+                              (set-property accounts account 0))))
+
+!(def create-account (lambda (state pub-key)
+                       (let ((account (derive-account (getf state :id) pub-key))
+                             (new-state (update-property state :accounts (maybe-add-account account))))
+                         (if (eq state new-state)
+                             (cons (list :error :account-exists))
+                             (cons (list :ok account) new-state)))))
+
+!(def balance (lambda (state pub-key)
+                (getf (getf state :accounts) pub-key)))
+
+!(def authenticate-account (lambda (account) (authenticate account)))
+
+!(def authenticate-owner (lambda (state) (authenticate (getf state :owner))))
+
+!(def check-balance (lambda (state pub-key)
+                      (cons (balance state pub-key) state)))
+
+!(def grant
+     (evl macro-env (current-env)
+          '(lambda (state amount to)
+            (authenticate-owner state)
+            (cond ((< (getf state :supply) amount) (cons :insufficient-supply state))
+                  ((not (balance state to)) (cons (list :error :non-existent-recipient to) state))
+                  (t (let ((state (update-property state :supply (lambda (n) (- n amount))))
+                           (state (update-property state
+                                                   :accounts (lambda (accounts)
+                                                               (update-property accounts to
+                                                                                (lambda (n) (+ n amount)))))))
+                       (cons :ok state)))))))
+
+!(def transfer
+     (evl macro-env (current-env)
+          '(lambda (state amount from to)
+            (authenticate-account from)
+            (cond
+              ((not (balance state from)) (cons (list :error :non-existent-sender from) state))
+              ((not (balance state to)) (cons (list :error :non-existent-recipient to) state))
+              ((< (balance state from) amount) (cons (list :error :insufficient-funds) state))
+              (t (let ((state (update-property state
+                                               :accounts (lambda (accounts)
+                                                           (let ((accounts (update-property accounts to
+                                                                                            (lambda (n) (+ n amount)))))
+                                                             (update-property accounts from (lambda (n) (- n amount))))))))
+                   (cons :ok state)))))))
+
+!(def audit (lambda (state)
+              (let ((total-supply (+ (getf state :supply)
+                                     (fold-properties (lambda (a b) (+ a b))
+                                                      0
+                                                      (getf state :accounts)))))
+                (if (= total-supply (getf state :initial-supply))
+                    (cons :pass state)
+                    (cons :fail state)))))
+
+!(def invoke (lambda (fn state args)
+               ;; FIXME: Use builtin apply once #358 is fixed.
+               (applyx fn (cons state args))))
+
+!(def handle-input
+     (evl macro-env (current-env)
+          '(lambda (state input)
+            (letrec
+                ((aux
+                  (lambda (state input)
+                    (let ((reply (lambda (output) (cons output (aux state))))
+                          (reply-with-state (lambda (output state) (cons output (aux state))))
+                          (unpack-reply (lambda (result) (reply-with-state (car result) (cdr result))))
+                          (delegate-reply (lambda (fn expected-args)
+                                            (let ((args (cdr input)))
+                                              (if (= expected-args (length args))
+                                                  (unpack-reply (invoke fn state args))
+                                                  (reply (list :error :wrong-number-of-args)))))))
+                      (or (typecase input
+                            (:keyword
+                             (or (case input
+                                   (:help (reply help-message))
+                                   (:about (reply (getf state :about)))
+                                   (:options (reply (getf state :options)))
+                                   (:state (reply state))
+                                   (:id (reply (getf state :id)))
+                                   (:supply (reply (getf state :supply)))
+                                   (:audit (unpack-reply (audit state))))
+                                 (reply :unknown-command)))
+                            ((cons . case)
+                             (or (case (car input)
+                                   (:create-account (delegate-reply create-account 1))
+                                   (:balance (delegate-reply check-balance 1))
+                                   (:grant (delegate-reply grant 2))
+                                   (:transfer (delegate-reply transfer 3)))
+                                 (reply :unknown-command))))
+                          (reply :unknown-command))))))
+              (aux state input)))))
+
+!(defrec process-option
+     (evl macro-env (current-env)
+          '(lambda (state key value)
+            (or (case key
+                  ;; TODO: implement -> (thread-first) macro to make this nicer.
+                  (:initial-supply (set-property (set-property state :initial-supply value) :supply value))
+                  (:owner (set-property state :owner value))
+                  (:id (set-property state :id value))
+                  (:about (set-property state :about value)))
+             state))))
+
+!(defrec process-options (lambda (state options)
+                           (if options
+                               (process-options (process-option state (car options) (cadr options))
+                                                (cddr options))
+                               state)))
+
+;; Put the options in the initial state for transparency.
+!(def initial-state (lambda (options)
+                      (let ((state (process-options (list :options options :accounts ()) options))
+                            (id (getf state :id)))
+                        (if id
+                            (update-property state :owner (derive-account id))
+                            state))))
+
+!(assert-eq '(:options (:foo 123) :accounts ()) (initial-state '(:foo 123)))
+
+!(def make-bank (lambda (options) (handle-input (initial-state options))))
+
+!(def genesis (lambda (options)
+                (cons nil (make-bank options))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests
+
+!(def bank-id !(rand))
+!(def owner (make-pub-key "Owner" !(rand)))
+!(def about "This is my bank. There are many like it, but this one is mine.")
+!(def options (list :initial-supply 10000 :owner owner :id bank-id :about about))
+
+!(def no-account (make-pub-key "No Account" !(rand)))
+
+!(def s0 (genesis options))
+
+!(defq s1 !(transition s0 :foo))
+!(assert-eq :unknown-command (car s1))
+
+;; TODO: tests for non-keyword and cons-shaped unknown commands.
+
+!(defq s2 !(transition s1 :help))
+!(assert-eq help-message (car s2))
+
+!(defq s3 !(transition s2 :options))
+!(assert-eq options (car s3))
+
+!(defq s4 !(transition s3 :state))
+!(assert-eq (list :about about :id bank-id :owner (derive-account bank-id owner) :supply 10000 :initial-supply 10000 :options options :accounts ()) (car s4))
+
+!(assert-eq bank-id (car '!(transition s4 :id)))
+!(assert-eq about (car '!(transition s4 :about)))
+
+!(def bob-key (make-pub-key "Bob" !(rand)))
+!(defq s5 !(transition s4 (list :create-account bob-key)))
+!(assert-eq :ok (caar s5))
+!(def bob (cadar s5))
+
+!(def alice-key (make-pub-key "Alice" !(rand)))
+!(defq s6 !(transition s5 (list :create-account alice-key)))
+!(assert-eq :ok (caar s6))
+!(def alice (cadar s6))
+
+;; TODO: test create-account with existing account
+
+!(defq s7 !(transition s6 (list :grant 1000 alice)))
+!(assert-eq :ok (car s7))
+
+!(assert-eq (cons :insufficient-supply (cdr s7)) '!(transition s7 (list :grant 9999999 alice)))
+!(assert-eq (list :error :non-existent-recipient no-account) (car '!(transition s7 (list :grant 1000 no-account))))
+
+!(defq s8 !(transition s7 (list :balance alice)))
+!(assert-eq 1000 (car s8))
+
+!(defq s9 !(transition s8 :supply))
+!(assert-eq 9000 (car s9))
+
+!(defq s10 !(transition s9 (list :transfer 100 alice bob)))
+!(assert-eq :ok (car s10))
+
+!(assert-eq 900 (car '!(transition s10 (list :balance alice))))
+!(assert-eq 100 (car '!(transition s10 (list :balance bob))))
+
+!(defq s11 !(transition s10 (list :transfer 100 alice no-account)))
+!(assert-eq (list :error :non-existent-recipient no-account) (car s11))
+!(assert-eq (cdr s10) (cdr s11))
+
+!(defq s12 !(transition s11 (list :transfer 100 no-account bob)))
+!(assert-eq (list :error :non-existent-sender no-account) (car s12))
+!(assert-eq (cdr s11) (cdr s12))
+
+!(defq s13 !(transition s7 :audit))
+!(assert-eq  :pass (car s13))

--- a/lib/lib.lurk
+++ b/lib/lib.lurk
@@ -1,0 +1,6 @@
+;; Loading this file should load all library functions and the appropriate macro-env. For now, just loading macros.lurk
+;; accomplishes this, but as the library evolves, so should this easiest entrypoint.
+;;
+;; The goal is that consuming code should just !(load "lib.lurk").
+
+!(load "macros.lurk")

--- a/lib/macro-test.lurk
+++ b/lib/macro-test.lurk
@@ -83,3 +83,7 @@
 !(assert-eq :b (qux :a :b :c))
 !(assert-eq :c (qux :a nil :c))
 !(assert-eq 123 (qux nil nil nil))
+
+!(assert-eq '(type-eqq (foo :x) (baz 123)) (macroexpand-all macro-env '(type-eqq (foo :x) (foo 123))))
+!(assert-eq '(eqq (foo :x) (baz 123)) (macroexpand-all macro-env '(eqq (foo :x) (foo 123))))
+

--- a/lib/macro-test.lurk
+++ b/lib/macro-test.lurk
@@ -74,10 +74,10 @@
                                 (or (and a b c)
                                  (if (foo x) (bar y) (and (bar x) (foo y))))))))
 
-!(def qux (evl macro-env '(lambda (a b c)
+!(def qux (evl1 macro-env '(lambda (a b c)
                             (or (and a b)
-                                (and a c)
-                                123))))
+                             (and a c)
+                             123))))
 
 !(assert-eq 123 (qux nil :b :c))
 !(assert-eq :b (qux :a :b :c))

--- a/lib/macro.lurk
+++ b/lib/macro.lurk
@@ -45,17 +45,15 @@
                                                                    (list (car binding) (macroexpand-all macro-env (cadr binding))))
                                                                  (cadr expanded))
                                                             (macroexpand-all macro-env (cddr expanded))))
-                                           (if (eq head 'lambda)
+                                           (if (member? head '(lambda type-eqq 'eqq))
                                                (cons 'lambda
                                                      (cons (cadr expanded)
                                                            (map (macroexpand-all macro-env) (cddr expanded))))
                                                (map (macroexpand-all macro-env) expanded)))))
                                  expanded))))
 
-!(def eval-with-macro-env (lambda (macro-env src env)
-                            (eval (macroexpand-all src) env)))
+!(def evl (lambda (macro-env env src)
+                            (eval (macroexpand-all macro-env src) env)))
 
-!(def eval-with-macro-env1 (lambda (macro-env src)
+!(def evl1 (lambda (macro-env src)
                             (eval (macroexpand-all macro-env src))))
-
-!(def evl (lambda (macro-env src) (eval-with-macro-env1 macro-env src)))

--- a/lib/macro.lurk
+++ b/lib/macro.lurk
@@ -45,15 +45,15 @@
                                                                    (list (car binding) (macroexpand-all macro-env (cadr binding))))
                                                                  (cadr expanded))
                                                             (macroexpand-all macro-env (cddr expanded))))
-                                           (if (member? head '(lambda type-eqq 'eqq))
-                                               (cons 'lambda
+                                           (if (member? head '(eqq type-eqq lambda))
+                                               (cons head
                                                      (cons (cadr expanded)
                                                            (map (macroexpand-all macro-env) (cddr expanded))))
                                                (map (macroexpand-all macro-env) expanded)))))
                                  expanded))))
 
 !(def evl (lambda (macro-env env src)
-                            (eval (macroexpand-all macro-env src) env)))
+            (eval (macroexpand-all macro-env src) env)))
 
 !(def evl1 (lambda (macro-env src)
-                            (eval (macroexpand-all macro-env src))))
+             (eval (macroexpand-all macro-env src))))

--- a/lib/macros-test.lurk
+++ b/lib/macros-test.lurk
@@ -12,4 +12,13 @@
 !(assert-eq '(if a a (if b b c)) (macroexpand-all macro-env '(or a b c)))
 
 ;; cond
-!(assert-eq '(if a 1 (if b 2 (if t 3 nil))) (macroexpand-all macro-env '(cond ((a 1) (b 2) (t 3)))))
+!(assert-eq '(if a 1 (if b 2 (if t 3 nil))) (macroexpand-all macro-env '(cond (a 1) (b 2) (t 3))))
+
+;; typecase
+
+!(assert-eq '(cond
+              ((type-eqq 0 x) 123)
+              ((type-eqq 'x' x) 321))
+            (macroexpand-1 macro-env '(typecase x
+                                       (0 123)
+                                       ('x' 321))))

--- a/lib/macros-test.lurk
+++ b/lib/macros-test.lurk
@@ -15,7 +15,6 @@
 !(assert-eq '(if a 1 (if b 2 (if t 3 nil))) (macroexpand-all macro-env '(cond (a 1) (b 2) (t 3))))
 
 ;; typecase
-
 !(assert-eq '(cond
               ((type-eqq 0 x) 123)
               ((type-eqq 'x' x) 321))
@@ -24,7 +23,6 @@
                                        ('x' 321))))
 
 ;; case
-
 !(assert-eq '(cond
               ((eqq 0 x) 123)
               ((eqq 'x' x) 321))

--- a/lib/macros-test.lurk
+++ b/lib/macros-test.lurk
@@ -22,3 +22,12 @@
             (macroexpand-1 macro-env '(typecase x
                                        (0 123)
                                        ('x' 321))))
+
+;; case
+
+!(assert-eq '(cond
+              ((eqq 0 x) 123)
+              ((eqq 'x' x) 321))
+            (macroexpand-1 macro-env '(case x
+                                       (0 123)
+                                       ('x' 321))))

--- a/lib/macros.lurk
+++ b/lib/macros.lurk
@@ -7,30 +7,40 @@
                             (lambda (whole)
                               (if (cdr whole)
                                   (if (cdr (cdr whole))
-                                      (list 'if (car (cdr whole))
-                                            (cons 'and (cdr (cdr whole))))
-                                      (car (cdr whole)))
+                                      (list 'if (cadr whole)
+                                            (cons 'and (cddr whole)))
+                                      (cadr whole))
                                   t))))
 
 !(def macro-env (bind-macro 'or macro-env
                             (lambda (whole)
                               (if (cdr whole)
-                                  (if (cdr (cdr whole))
-                                      (list 'if (car (cdr whole))
-                                            (car (cdr whole)) ;; this is memoized
-                                            (cons 'or (cdr (cdr whole))))
-                                      (car (cdr whole)))
+                                  (if (cddr whole)
+                                      (list 'if (cadr whole)
+                                            (cadr whole) ;; this is memoized
+                                            (cons 'or (cddr whole)))
+                                      (cadr whole))
                                   nil))))
 
 !(def macro-env (bind-macro 'cond macro-env
                             (lambda (whole)
                               (letrec ((aux (lambda (clauses)
                                               (if clauses
-                                                  (list 'if
-                                                        (caar clauses)
-                                                        (cadar clauses)
-                                                        (aux (cdr clauses))                                                        )
-                                                  nil))))
-                                (if (cdr (cdr whole)) (error "malformed cond")
-                                    (aux (car (cdr whole))))))))
+                                                  (if (cdddr (car clauses))
+                                                      (error (cons "malformed cond clause" (cdddr (car clauses))))
+                                                      (list 'if
+                                                            (caar clauses)
+                                                            (cadar clauses)
+                                                            (aux (cdr clauses))))))))
+                                (aux (cdr whole))))))
 
+!(def macro-env (bind-macro 'typecase macro-env
+                            (lambda (whole)
+                              (let ((var (cadr whole)))
+                                (letrec ((aux (lambda (clauses)
+                                                (if clauses
+                                                    (if (cddar clauses)
+                                                        (error (cons "malformed typecase clause" (cddar clauses)))
+                                                        (cons (list (list 'type-eqq (caar clauses) var) (cadar clauses))
+                                                              (aux (cdr clauses))))))))
+                                  (cons 'cond (aux (cddr whole))))))))

--- a/lib/macros.lurk
+++ b/lib/macros.lurk
@@ -1,5 +1,6 @@
-!(load "macro.lurk") ;; this will also load util.lurk.
-!(load "util.lurk")
+!(load "macro.lurk") ;; this will also load util.lurk, so we omit that below. An eventual better system would only load
+                     ;; dependencies once.
+;; !(load "util.lurk")
 
 !(def macro-env ())
 !(def macro-env (bind-macro 'and macro-env

--- a/lib/macros.lurk
+++ b/lib/macros.lurk
@@ -44,3 +44,14 @@
                                                         (cons (list (list 'type-eqq (caar clauses) var) (cadar clauses))
                                                               (aux (cdr clauses))))))))
                                   (cons 'cond (aux (cddr whole))))))))
+
+!(def macro-env (bind-macro 'case macro-env
+                            (lambda (whole)
+                              (let ((var (cadr whole)))
+                                (letrec ((aux (lambda (clauses)
+                                                (if clauses
+                                                    (if (cddar clauses)
+                                                        (error (cons "malformed case clause" (cddar clauses)))
+                                                        (cons (list (list 'eqq (caar clauses) var) (cadar clauses))
+                                                              (aux (cdr clauses))))))))
+                                  (cons 'cond (aux (cddr whole))))))))

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -3,7 +3,7 @@
 ;; todo
 !(assert-error (todo :rest-of-owl))
 
-;; break
+;; error
 !(assert-error (error :nasty 123))
 
 ;; assert
@@ -41,18 +41,21 @@
 
 ;; getf
 !(assert-eq 2 (getf '(:a 1 :b 2 :c 3) :b))
-(emit (cons :getf-2 (getf '(:a 1 :b 2 :c 3) :b))) ; 30 iterations
-
+;(emit (cons :getf-2 (getf '(:a 1 :b 2 :c 3) :b))) ; 30 iterations
 !(assert-eq nil (getf '(:a 1 :b 2 :c 3) :d))
 
 ;; set-property
-
 !(assert-eq '(:a 1 :b 2) (set-property '(:b 2) :a 1))
 !(assert-eq '(:a 1 :b 4 :c 3) (set-property '(:a 1 :b 2 :c 3) :b 4))
 
 ;; update-property
-
 !(assert-eq '(:a 1 :b 6 :c 3) (update-property '(:a 1 :b 2 :c 3) :b (lambda (x) (* 3 x))))
+
+;; fold-properties
+!(assert-eq 6 (fold-properties (lambda (a b) (+ a b)) 0 '(:a 1 :b 2 :c 3)))
+
+;; map-properties
+!(assert-eq '(2 4 6) (map-properties (lambda (x) (* 2 x)) '(:a 1 :b 2 :c 3)))
 
 ;; assoc
 !(assert-eq '(:b . 2) (assoc :b '((:a . 1) (:b . 2) (:c . 3))))
@@ -91,3 +94,11 @@
                      (double (lambda (x) (* 2 x)))
                      (double-then-square (compose square double)))
                  (double-then-square 3)))
+
+;; not
+!(assert-eq t (not nil))
+!(assert-eq nil (not t))
+!(assert-eq nil (not 123))
+
+;; fold
+!(assert-eq 15 (fold (lambda (a b) (+ a b)) 0 '(1 2 3 4 5)))

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -50,6 +50,10 @@
 !(assert-eq '(:a 1 :b 2) (set-property '(:b 2) :a 1))
 !(assert-eq '(:a 1 :b 4 :c 3) (set-property '(:a 1 :b 2 :c 3) :b 4))
 
+;; update-property
+
+!(assert-eq '(:a 1 :b 6 :c 3) (update-property '(:a 1 :b 2 :c 3) :b (lambda (x) (* 3 x))))
+
 ;; assoc
 !(assert-eq '(:b . 2) (assoc :b '((:a . 1) (:b . 2) (:c . 3))))
 (emit (cons :assoc-b (assoc :b '((:a . 1) (:b . 2) (:c . 3))))) ;; 29 iterations

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -45,6 +45,11 @@
 
 !(assert-eq nil (getf '(:a 1 :b 2 :c 3) :d))
 
+;; set-property
+
+!(assert-eq '(:a 1 :b 2) (set-property '(:b 2) :a 1))
+!(assert-eq '(:a 1 :b 4 :c 3) (set-property '(:a 1 :b 2 :c 3) :b 4))
+
 ;; assoc
 !(assert-eq '(:b . 2) (assoc :b '((:a . 1) (:b . 2) (:c . 3))))
 (emit (cons :assoc-b (assoc :b '((:a . 1) (:b . 2) (:c . 3))))) ;; 29 iterations

--- a/lib/util.lurk
+++ b/lib/util.lurk
@@ -10,8 +10,8 @@
 !(def cadar (lambda (x) (car (cdr (car x)))))
 !(def caddr (lambda (x) (car (cdr (cdr x)))))
 !(def cdaar (lambda (x) (cdr (car (car x)))))
-!(def cdadr (lambda (x) (cdr (car (cdar x)))))
-!(def caddr (lambda (x) (car (cdr (cdr x)))))
+!(def cdadr (lambda (x) (cdr (car (cdr x)))))
+!(def cddar (lambda (x) (cdr (cdr (car x)))))
 !(def cdddr (lambda (x) (cdr (cdr (cdr x)))))
 
 !(def todo (lambda (x)
@@ -20,9 +20,9 @@
               ;; this will error
               (break))))
 
-!(def error (lambda (type data)
+!(def error (lambda (data)
               (begin
-               (emit (list :error (list type data)))
+               (emit (list :error data))
               ;; this will error
               (break))))
 
@@ -94,6 +94,14 @@
                        (if found
                          (revappend (car found)
                                     (cons indicator (cons value (cdr (cdr found))))) ; memoized
+                         (cons indicator (cons value plist))))))
+
+!(def update-property (lambda (plist indicator update-fn)
+                     (let ((found (set-property-aux plist indicator)))
+                       (if found
+                         (revappend (car found)
+                                    (cons indicator (cons (update-fn (car (cdr found)))
+                                                          (cdr (cdr found))))) ; memoized
                          (cons indicator (cons value plist))))))
 
 !(def assoc (lambda (item alist)

--- a/lib/util.lurk
+++ b/lib/util.lurk
@@ -104,6 +104,21 @@
                                                           (cdr (cdr found))))) ; memoized
                          (cons indicator (cons value plist))))))
 
+!(def fold-properties (lambda (f acc plist)
+                       (letrec ((aux (lambda (acc plist)
+                                       (if (cdr plist)
+                                           (aux (f acc (cadr plist))
+                                                (cddr plist))
+                                           acc))))
+                         (aux acc plist))))
+
+!(def map-properties (lambda (f plist)
+                       (letrec ((aux (lambda (plist)
+                                       (if (cdr plist)
+                                           (cons (f (cadr plist))
+                                                 (aux (cddr plist)))))))
+                         (aux plist))))
+
 !(def assoc (lambda (item alist)
               (letrec ((aux (lambda (alist)
                               (if alist
@@ -162,3 +177,22 @@
 ;; todo: make variadic when possible
 !(def compose (lambda (a b)
                 (lambda (x) (a (b x)))))
+
+;; FIXME: Remove this once #358 is fixed. This is just a workaround. The renaming is because builtin apply cannot be
+;; shadowed.
+!(defrec applyx (lambda (f args)
+                  (if args
+                      (if (cdr args)
+                          (apply (f (car args)) (cdr args))
+                          (f (car args))))))
+
+!(def not (lambda (x) (if x nil t)))
+
+!(def fold (lambda (f acc list)
+             (letrec ((aux (lambda (acc list)
+                             (if list
+                                 (aux (f acc (car list))
+                                      (cdr list))
+                                 acc))))
+               (aux acc list))))
+

--- a/lib/util.lurk
+++ b/lib/util.lurk
@@ -78,6 +78,24 @@
                                      (aux (cdr (cdr plist))))))))
                (aux plist))))
 
+!(def set-property-aux
+     (lambda (plist indicator)
+       (letrec ((aux (lambda (acc plist)
+                       (if plist
+                           (if (eq (car plist) indicator)
+                               (cons acc (cdr plist))
+                               (aux (cons (cadr plist)
+                                          (cons (car plist) acc))
+                                    (cdr (cdr plist))))))))
+         (aux nil plist))))
+
+!(def set-property (lambda (plist indicator value)
+                     (let ((found (set-property-aux plist indicator)))
+                       (if found
+                         (revappend (car found)
+                                    (cons indicator (cons value (cdr (cdr found))))) ; memoized
+                         (cons indicator (cons value plist))))))
+
 !(def assoc (lambda (item alist)
               (letrec ((aux (lambda (alist)
                               (if alist

--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -590,7 +590,7 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> MetaCmd<F, C1, C2> {
         summary: "Chains a callable object and binds the next state to a variable",
         info: &["It has the same side effects of the `chain` meta command."],
         format: "!(transition <state_expr> <call_args>)",
-        example: &["!(transition new-state old-state input0)"],
+        example: &["!(defq new-state !(transition old-state input))"],
         returns: "The chained result",
         run: |repl, args, _dir| {
             let (&current_state_expr, &call_args) = repl.car_cdr(args);

--- a/src/lurk/cli/tests/mod.rs
+++ b/src/lurk/cli/tests/mod.rs
@@ -51,6 +51,8 @@ fn test_demo_files() {
         "demo/protocol.lurk",
         "demo/bank.lurk",
         "demo/mastermind.lurk",
+        "demo/mini-mastermind.lurk",
+        "demo/microbank.lurk",
     ];
     for file in demo_files {
         let mut repl = Repl::new_native();


### PR DESCRIPTION
This is the successor to the [bank demo](https://github.com/argumentcomputer/lurk/blob/main/demo/bank.lurk).

It does not attempt to be self-contained. Instead it exists partially to work out design patterns for microchain applications, and to help drive library development. It relies on user-level macros, which will eventually be replaced by language-level macros.

This iteration contains a command-driven interaction model. It uses commitment-based authentication with the following features:

- Bank is created by owner who initializes the total supply of single currency.
- Anyone can create an account.
- Owner can grant funds to any account (reducing the bank's supply).
- Account owners can transfer funds to other accounts (reducing their own balance).
- Anyone can audit the bank, receiving confirmation that the audit provably passes if total of all accounts and bank's supply equals the initial supply.
- Account authentication secrets are derived from public keys and bank id — minimizing need to expose 'private key' secrets with which account was created even locally while interacting with this chain.

NOTE: balances are not private, and neither is the bank's supply — so individuals could also audit the total supply on their own.

The song and dance separating pub-keys and accounts is partially present to drive development of tooling to help manage secrets and support data hygiene.
