### PR TITLE
feat: persisting microchain server data

### DIFF
--- a/src/lurk/cli/comm_data.rs
+++ b/src/lurk/cli/comm_data.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::zdag::ZDag;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub(crate) struct CommData<F: Hash + Eq> {
     pub(crate) secret: [F; DIGEST_SIZE],
     pub(crate) payload: ZPtr<F>,

--- a/src/lurk/cli/lurk_data.rs
+++ b/src/lurk/cli/lurk_data.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::zdag::ZDag;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub(crate) struct LurkData<F: std::hash::Hash + Eq> {
     pub(crate) zptr: ZPtr<F>,
     zdag: ZDag<F>,

--- a/src/lurk/cli/paths.rs
+++ b/src/lurk/cli/paths.rs
@@ -32,6 +32,11 @@ pub(crate) fn commits_dir() -> Result<Utf8PathBuf> {
 }
 
 #[inline]
+pub(crate) fn microchains_dir() -> Result<Utf8PathBuf> {
+    create_dir_all_and_return(get_config().lurk_dir.join("microchains"))
+}
+
+#[inline]
 pub(crate) fn repl_history() -> Result<Utf8PathBuf> {
     Ok(lurk_dir()?.join("repl-history"))
 }

--- a/src/lurk/cli/proofs.rs
+++ b/src/lurk/cli/proofs.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{lurk_data::LurkData, microchain::CallableData, zdag::ZDag};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 struct CryptoShardProof {
     commitment: ShardCommitment<Com<BabyBearPoseidon2>>,
     opened_values: ShardOpenedValues<Challenge<BabyBearPoseidon2>>,
@@ -27,7 +27,7 @@ struct CryptoShardProof {
     chip_ordering: HashMap<String, usize>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub(crate) struct CryptoProof {
     shard_proofs: Vec<CryptoShardProof>,
     verifier_version: String,
@@ -133,7 +133,7 @@ impl From<MachineProof<BabyBearPoseidon2>> for CryptoProof {
 /// Carries a cryptographic proof and the Lurk data for its public values. This
 /// proof format is meant for local caching through filesystem persistence. The
 /// Lurk data for its public values is fully specified to support inspection.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub(crate) struct CachedProof {
     pub(crate) crypto_proof: CryptoProof,
     pub(crate) expr: ZPtr<F>,
@@ -210,7 +210,7 @@ pub(crate) struct ChainProof {
 
 /// A slightly smaller version of `ChainProof` meant to be kept as transition
 /// record and shared for verification purposes.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub(crate) struct OpaqueChainProof {
     pub(crate) crypto_proof: CryptoProof,
     pub(crate) call_args: ZPtr<F>,

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Holds Lurk data meant to be persisted and/or shared
-#[derive(Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Serialize, Deserialize)]
 pub(crate) struct ZDag<F: std::hash::Hash + Eq>(FxHashMap<ZPtr<F>, ZPtrType<F>>);
 
 impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {


### PR DESCRIPTION
Instead of bloating the server's RAM with data from potentially many microchains, persist the data on the file system. This allows servers to not lose data on temporary shutdowns.