### PR TITLE
chore: change `call`-based meta commands

### DIFF
--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -198,11 +198,11 @@ ledger2
 
 ;; Let's prove it.
 
-!(prove)
+!(defq proof-key !(prove))
 
 ;; We can verify the proof..
 
-!(verify "3ec2be088404f2c65da6a7f8d9c48d7acadf902462fe55d8c0683a9bfc88be")
+!(verify proof-key)
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -219,24 +219,24 @@ ledger2
 
 ;; Now we can transfer one unit from Church to Satoshi like before.
 
-!(chain #0x55e9e42540b3915fcd357bac7fb5ad5e6f299cd9619e11d44a95a26fa41aa '(1 0 2))
+!(chain #c0x4614f15d0b541b70d7975d5004526b7f824579c4f80c24e95796b9fe22837b '(1 0 2))
 
-!(prove)
+!(defq proof-key !(prove))
 
-!(verify "45e9ae74bd1c72778da7985f55a096b4f2c772eec3d00a78b051e69c0b351d")
+!(verify proof-key)
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
-!(chain #0x6018ec368c1130fa5ed4777a33de94e21b0ab4964ea8d3718bfff44b51eb3e '(5 0 2))
+!(chain #c0x76a11678f6ae8a9126175ce8d793188a09f43d03cfa93c8b760f9eda283567 '(5 0 2))
 
-!(prove)
+!(defq proof-key !(prove))
 
-!(verify "49ecca3674d380af21c617e714866e334acc144989632a7ccd244295a64628")
+!(verify proof-key)
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
-!(chain #0x8a0964dc644afdecdee4fa6687e55744290a591e6d1c0468f1fffba4c5059c '(20 1 0))
+!(chain #c0x300f43e37bfc756d852a94fcdbf02cc18e1b009f75e3cd3379c93bdfa5cf6a '(20 1 0))
 
-!(prove)
+!(defq proof-key !(prove))
 
-!(verify "79bc2aa3e3fcc71ee28a1e0b05c507a4ccb72a4e7158194b80ec96522bc63f")
+!(verify proof-key)

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -21,7 +21,7 @@
 
 ;; We can verify the proof.
 
-!(verify "11207b18c7ff19e5453f44c56c524afd68286e2d11e1bc279d72481da32e1")
+!(verify "7f3d461431be8938b524623db27645a1bdcb8805db1067d2cc9c5013e0928b")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
@@ -35,7 +35,7 @@
 
 ;; And verify.
 
-!(verify "61948c697ea4756c4f4c6f47d44af1e4f7174a94e16f6fac3f4e84d13ec65a")
+!(verify "2033209771e7e82aaec1cdc835f95485b84a5c57d78174e1c063efe60557e7")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "4f2554b0723e723c82fda0b00368bc676f961b0024085b0b74822317a6c513")
+!(verify "88e2918c83d6d1744e6833c955098080171b428cc71a9c0bdc4ab5c84573e")
 
 ;; Repeat indefinitely.
 

--- a/demo/functional-commitment.lurk
+++ b/demo/functional-commitment.lurk
@@ -18,8 +18,8 @@
 
 ;; We can inspect the input/output expressions of the proof.
 
-!(inspect "3863a71b55ec6f53d1547e503bc69491e87e57063143e7dc62b1a91de4ef7")
+!(inspect "22871b51b8749ed2ed139627d7cb36d029090b1dea265e42715d9ab09be783")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(verify "3863a71b55ec6f53d1547e503bc69491e87e57063143e7dc62b1a91de4ef7")
+!(verify "22871b51b8749ed2ed139627d7cb36d029090b1dea265e42715d9ab09be783")


### PR DESCRIPTION
`call`, `chain`, `transition` and `microchain-transition` will now evaluate their arguments out of circuit and assemble the call expr to be proved using the evaluated, but quoted, arguments.