### PR TITLE
fix: use correct arguments and env for chain transitions

### DIFF
--- a/src/core/cli/comm_data.rs
+++ b/src/core/cli/comm_data.rs
@@ -3,10 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
 use crate::{
-    core::{
-        tag::Tag,
-        zstore::{ZPtr, ZStore, DIGEST_SIZE, HASH3_SIZE},
-    },
+    core::zstore::{ZPtr, ZStore, DIGEST_SIZE, HASH3_SIZE},
     lair::chipset::Chipset,
 };
 
@@ -35,15 +32,14 @@ impl<F: Field> CommData<F> {
 impl<F: Hash + Eq + Default + Copy> CommData<F> {
     #[inline]
     pub(crate) fn new<C: Chipset<F>>(
-        secret: ZPtr<F>,
+        secret: [F; DIGEST_SIZE],
         payload: ZPtr<F>,
         zstore: &ZStore<F, C>,
     ) -> Self {
-        assert_eq!(secret.tag, Tag::BigNum);
         let mut zdag = ZDag::default();
-        zdag.populate_with_many([&secret, &payload], zstore);
+        zdag.populate_with(&payload, zstore, &mut Default::default());
         Self {
-            secret: secret.digest,
+            secret,
             payload,
             zdag,
         }

--- a/src/core/cli/repl.rs
+++ b/src/core/cli/repl.rs
@@ -484,11 +484,14 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
         result_data.map(|data| ZPtr::from_flat_data(&data))
     }
 
-    /// Evaluates an expression with the current REPL env and prints the number
-    /// of iterations and the result. The computation is cached for proving.
-    pub(crate) fn handle_non_meta(&mut self, expr: &ZPtr<F>) -> Result<ZPtr<F>> {
-        let env = self.env;
-        let result = self.reduce_with_env(expr, &env)?;
+    /// Evaluates an expression with a custom env and prints the number of
+    /// iterations and the result. The computation is cached for proving.
+    pub(crate) fn handle_non_meta_with_env(
+        &mut self,
+        expr: &ZPtr<F>,
+        env: &ZPtr<F>,
+    ) -> Result<ZPtr<F>> {
+        let result = self.reduce_with_env(expr, env)?;
         self.memoize_dag(&result);
         let iterations = self.queries.func_queries[self.func_indices.eval].len();
         println!(
@@ -497,6 +500,11 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
             self.fmt(&result)
         );
         Ok(result)
+    }
+
+    pub(crate) fn handle_non_meta(&mut self, expr: &ZPtr<F>) -> Result<ZPtr<F>> {
+        let env = self.env;
+        self.handle_non_meta_with_env(expr, &env)
     }
 
     fn intern_syntax_slice(


### PR DESCRIPTION
The arguments must be the evaluated+quoted ones and the env must be empty.