### PR TITLE
feat: `env` and `bind` built-ins

### DIFF
--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -269,7 +269,7 @@ const USER_PACKAGE_NAME: &str = "lurk-user";
 
 pub(crate) const LURK_SYMBOLS: [&str; 3] = ["nil", "t", "&rest"];
 
-pub(crate) const BUILTIN_SYMBOLS: [&str; 41] = [
+pub(crate) const BUILTIN_SYMBOLS: [&str; 43] = [
     "atom",
     "apply",
     "begin",
@@ -280,9 +280,11 @@ pub(crate) const BUILTIN_SYMBOLS: [&str; 41] = [
     "comm",
     "bignum",
     "cons",
-    "current-env",
-    "emit",
     "empty-env",
+    "current-env",
+    "bind",
+    "env",
+    "emit",
     "eval",
     "eq",
     "eqq",

--- a/src/core/tests/eval_compiled.rs
+++ b/src/core/tests/eval_compiled.rs
@@ -359,6 +359,33 @@ test!(
 );
 // TODO FIXME
 // test_env!(test_manual_env, "a", trivial_a_1_env, |_| uint(1));
+// test!(test_env_builtin, "(env (cons 'a 1) (cons 'b 2))", |z| {
+//     let empty_env = z.intern_empty_env();
+//     let b = z.intern_symbol_no_lang(&user_sym("b"));
+//     let two = z.intern_u64(2);
+//     let b_2 = z.intern_env(b, two, empty_env);
+//     let a = z.intern_symbol_no_lang(&user_sym("a"));
+//     let one = z.intern_u64(1);
+//     z.intern_env(a, one, b_2)
+// });
+// test!(test_env_builtin2, "(env)", |z| z.intern_empty_env());
+// test!(
+//     test_env_builtin3,
+//     "(env (list 'a 1 2))",
+//     |z| {
+//         let empty_env = z.intern_empty_env();
+//         let a = z.intern_symbol_no_lang(&user_sym("a"));
+//         let one = z.intern_u64(1);
+//         let two = z.intern_u64(2);
+//         let val = z.intern_list([one, two]);
+//         z.intern_env(a, val, empty_env)
+//     }
+// );
+// test!(
+//     test_bind_builtin,
+//     "(bind 'a (- 2 1) (current-env))",
+//     trivial_a_1_env
+// );
 
 // heavier computations
 test!(

--- a/src/core/tests/eval_direct.rs
+++ b/src/core/tests/eval_direct.rs
@@ -349,6 +349,29 @@ test!(
     trivial_a_1_env
 );
 test_env!(test_manual_env, "a", trivial_a_1_env, |_| uint(1));
+test!(test_env_builtin, "(env (cons 'a 1) (cons 'b 2))", |z| {
+    let empty_env = z.intern_empty_env();
+    let b = z.intern_symbol_no_lang(&user_sym("b"));
+    let two = z.intern_u64(2);
+    let b_2 = z.intern_env(b, two, empty_env);
+    let a = z.intern_symbol_no_lang(&user_sym("a"));
+    let one = z.intern_u64(1);
+    z.intern_env(a, one, b_2)
+});
+test!(test_env_builtin2, "(env)", |z| z.intern_empty_env());
+test!(test_env_builtin3, "(env (list 'a 1 2))", |z| {
+    let empty_env = z.intern_empty_env();
+    let a = z.intern_symbol_no_lang(&user_sym("a"));
+    let one = z.intern_u64(1);
+    let two = z.intern_u64(2);
+    let val = z.intern_list([one, two]);
+    z.intern_env(a, val, empty_env)
+});
+test!(
+    test_bind_builtin,
+    "(bind 'a (- 2 1) (current-env))",
+    trivial_a_1_env
+);
 
 // heavier computations
 test!(


### PR DESCRIPTION
Implement `env` and `bind` as primitives for env construction.

Extra:
* Adapt the microchain server to send only a slice of the transition proofs, chosen by the client. This is necessary for when the VM changes (as in this patch) and the client would no longer accept old proofs sent by the server. Then the client can reconsider what qualifies as the new genesis and verify proofs from there.