### PR TITLE
Return chips refactors

### DIFF
--- a/src/air/builder.rs
+++ b/src/air/builder.rs
@@ -136,6 +136,7 @@ impl<AB: AirBuilder + MessageBuilder<AirInteraction<AB::Expr>>> LookupBuilder fo
 pub struct Record {
     pub nonce: u32,
     pub count: u32,
+    pub query_index: u32,
 }
 
 impl Record {

--- a/src/air/builder.rs
+++ b/src/air/builder.rs
@@ -136,15 +136,17 @@ impl<AB: AirBuilder + MessageBuilder<AirInteraction<AB::Expr>>> LookupBuilder fo
 pub struct Record {
     pub nonce: u32,
     pub count: u32,
-    pub query_index: u32,
+    // Original query that did the lookup. `None` is for the root lookup
+    pub query_index: Option<usize>,
 }
 
 impl Record {
     /// Updates the provide record and returns the require record
-    pub fn new_lookup(&mut self, nonce: u32) -> Record {
+    pub fn new_lookup(&mut self, nonce: u32, query_index: usize) -> Record {
         let require = *self;
         self.nonce = nonce;
         self.count += 1;
+        self.query_index = Some(query_index);
         require
     }
 

--- a/src/core/big_num.rs
+++ b/src/core/big_num.rs
@@ -45,12 +45,13 @@ impl<F: PrimeField32> Chipset<F> for BigNum {
         &self,
         input: &[F],
         nonce: u32,
+        query_index: usize,
         queries: &mut QueryRecord<F>,
         requires: &mut Vec<Record>,
     ) -> Vec<F> {
         let in1: [F; 8] = input[0..8].try_into().unwrap();
         let in2: [F; 8] = input[8..16].try_into().unwrap();
-        let bytes = &mut queries.bytes.context(nonce, requires);
+        let bytes = &mut queries.bytes.context(nonce, query_index, requires);
         match self {
             BigNum::LessThan => {
                 let mut witness = BigNumCompareWitness::<F>::default();

--- a/src/core/chipset.rs
+++ b/src/core/chipset.rs
@@ -123,15 +123,22 @@ impl Chipset<BabyBear> for LurkChip {
         &self,
         input: &[BabyBear],
         nonce: u32,
+        query_index: usize,
         queries: &mut QueryRecord<BabyBear>,
         requires: &mut Vec<Record>,
     ) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher3(hasher) => hasher.execute(input, nonce, queries, requires),
-            LurkChip::Hasher4(hasher) => hasher.execute(input, nonce, queries, requires),
-            LurkChip::Hasher5(hasher) => hasher.execute(input, nonce, queries, requires),
-            LurkChip::U64(op) => op.execute(input, nonce, queries, requires),
-            LurkChip::BigNum(op) => op.execute(input, nonce, queries, requires),
+            LurkChip::Hasher3(hasher) => {
+                hasher.execute(input, nonce, query_index, queries, requires)
+            }
+            LurkChip::Hasher4(hasher) => {
+                hasher.execute(input, nonce, query_index, queries, requires)
+            }
+            LurkChip::Hasher5(hasher) => {
+                hasher.execute(input, nonce, query_index, queries, requires)
+            }
+            LurkChip::U64(op) => op.execute(input, nonce, query_index, queries, requires),
+            LurkChip::BigNum(op) => op.execute(input, nonce, query_index, queries, requires),
         }
     }
 

--- a/src/core/u64.rs
+++ b/src/core/u64.rs
@@ -85,6 +85,7 @@ impl<F: PrimeField32> Chipset<F> for U64 {
         &self,
         input: &[F],
         nonce: u32,
+        query_index: usize,
         queries: &mut QueryRecord<F>,
         requires: &mut Vec<Record>,
     ) -> Vec<F> {
@@ -93,7 +94,7 @@ impl<F: PrimeField32> Chipset<F> for U64 {
             U64::IsZero => 0, // unused
             _ => into_u64(&input[8..16]),
         };
-        let bytes = &mut queries.bytes.context(nonce, requires);
+        let bytes = &mut queries.bytes.context(nonce, query_index, requires);
         match self {
             U64::Add => {
                 let mut witness = Sum64::<F>::default();

--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -509,20 +509,16 @@ impl<F: Field> Ctrl<F> {
         <AB as AirBuilder>::Var: Debug,
     {
         match self {
-            Ctrl::Choose(_, cases, branches) => {
+            Ctrl::Choose(_, _, branches) => {
                 let map_len = map.len();
                 let init_state = index.save();
 
-                let mut process = |block: &Block<F>| {
+                branches.iter().for_each(|block| {
                     let sel = block.return_sel::<AB>(local);
                     block.eval(builder, local, &sel, index, map, toplevel, depth);
                     map.truncate(map_len);
                     index.restore(init_state);
-                };
-                branches.iter().for_each(&mut process);
-                if let Some(block) = cases.default.as_ref() {
-                    process(block)
-                };
+                });
             }
             Ctrl::ChooseMany(_, cases) => {
                 let map_len = map.len();

--- a/src/lair/bytecode.rs
+++ b/src/lair/bytecode.rs
@@ -71,10 +71,10 @@ pub struct Block<F> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Ctrl<F> {
     /// `Choose(x, cases)` non-deterministically chooses which case to execute based on a value `x`
-    /// The third item is the list of unique branches, needed for `eval`
-    Choose(usize, Cases<F, F>, List<Block<F>>), // TODO use Arc or indices so that blocks are not duplicated
+    /// It works by mapping field elements into indices of the list of unique branches.
+    Choose(usize, Cases<F, usize>, List<Block<F>>),
     /// `ChooseMany(x, cases)` non-deterministically chooses which case to execute based on an array `x`
-    ChooseMany(List<usize>, Cases<List<F>, F>),
+    ChooseMany(List<usize>, Cases<List<F>, Block<F>>),
     /// Contains the variables whose bindings will construct the output of the
     /// block. The first `usize` is an unique identifier, representing the
     /// selector used for arithmetization
@@ -85,21 +85,21 @@ pub enum Ctrl<F> {
 /// matches and an optional default case in case there's no match. Each code path
 /// is encoded as its own block
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Cases<K, F> {
-    pub(crate) branches: Map<K, Block<F>>,
-    pub(crate) default: Option<Box<Block<F>>>,
+pub struct Cases<K, B> {
+    pub(crate) branches: Map<K, B>,
+    pub(crate) default: Option<Box<B>>,
 }
 
-impl<K: Ord, F> Cases<K, F> {
+impl<K: Ord, B> Cases<K, B> {
     /// Returns the block mapped from key `f`
     #[inline]
-    pub fn match_case(&self, k: &K) -> Option<&Block<F>> {
+    pub fn match_case(&self, k: &K) -> Option<&B> {
         self.branches.get(k).or(self.default.as_deref())
     }
 
     /// Returns the block at a given index
     #[inline]
-    pub fn get_index(&self, idx: usize) -> Option<&Block<F>> {
+    pub fn get_index(&self, idx: usize) -> Option<&B> {
         self.branches
             .get_index(idx)
             .map(|(_, b)| b)
@@ -117,7 +117,7 @@ impl<K: Ord, F> Cases<K, F> {
     }
 }
 
-impl<K, F> Cases<K, F> {
+impl<K, B> Cases<K, B> {
     /// Returns the size of `branches`, assuming that's the index of the default
     /// block
     #[inline]

--- a/src/lair/chipset.rs
+++ b/src/lair/chipset.rs
@@ -23,6 +23,7 @@ pub trait Chipset<F>: Sync {
         &self,
         input: &[F],
         _nonce: u32,
+        _query_index: usize,
         _queries: &mut QueryRecord<F>,
         _requires: &mut Vec<Record>,
     ) -> Vec<F>
@@ -65,6 +66,7 @@ impl<F, C1: Chipset<F>, C2: Chipset<F>> Chipset<F> for &Either<C1, C2> {
         &self,
         input: &[F],
         nonce: u32,
+        query_index: usize,
         queries: &mut QueryRecord<F>,
         requires: &mut Vec<Record>,
     ) -> Vec<F>
@@ -72,8 +74,8 @@ impl<F, C1: Chipset<F>, C2: Chipset<F>> Chipset<F> for &Either<C1, C2> {
         F: PrimeField32,
     {
         match self {
-            Either::Left(c) => c.execute(input, nonce, queries, requires),
-            Either::Right(c) => c.execute(input, nonce, queries, requires),
+            Either::Left(c) => c.execute(input, nonce, query_index, queries, requires),
+            Either::Right(c) => c.execute(input, nonce, query_index, queries, requires),
         }
     }
 

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -103,8 +103,7 @@ impl<'a, F: PrimeField32> Shard<'a, F> {
         self.queries.expect("Missing query record reference")
     }
 
-    pub fn get_func_range(&self, func_index: usize) -> Range<usize> {
-        let num_func_queries = self.queries().func_queries[func_index].len();
+    pub fn get_func_range(&self, num_func_queries: usize) -> Range<usize> {
         let shard_idx = self.index as usize;
         let max_shard_size = self.shard_config.max_shard_size as usize;
         shard_idx * max_shard_size..((shard_idx + 1) * max_shard_size).min(num_func_queries)

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -766,9 +766,10 @@ impl<F: PrimeField32> Func<F> {
                         break;
                     }
                 }
-                ExecEntry::Ctrl(Ctrl::Choose(v, cases, _)) => {
+                ExecEntry::Ctrl(Ctrl::Choose(v, cases, branches)) => {
                     let v = map[*v];
-                    let block = cases.match_case(&v).expect("No match");
+                    let i = cases.match_case(&v).expect("No match");
+                    let block = &branches[*i];
                     push_block_exec_entries!(block);
                 }
                 ExecEntry::Ctrl(Ctrl::ChooseMany(vs, cases)) => {

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -143,19 +143,15 @@ impl<F> Ctrl<F> {
                 // exactly one selector per return
                 *sel += 1;
             }
-            Ctrl::Choose(_, cases, branches) => {
+            Ctrl::Choose(_, _, branches) => {
                 let degrees_len = degrees.len();
                 let mut max_aux = *aux;
-                let mut process = |block: &Block<_>| {
+                branches.iter().for_each(|block| {
                     let block_aux = &mut aux.clone();
                     block.compute_layout_sizes(degrees, toplevel, block_aux, sel);
                     degrees.truncate(degrees_len);
                     max_aux = max_aux.max(*block_aux);
-                };
-                branches.iter().for_each(&mut process);
-                if let Some(block) = cases.default.as_ref() {
-                    process(block)
-                };
+                });
                 *aux = max_aux;
             }
             Ctrl::ChooseMany(_, cases) => {

--- a/src/lair/lair_chip.rs
+++ b/src/lair/lair_chip.rs
@@ -124,7 +124,8 @@ impl<'a, F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> MachineAir<F>
     fn included(&self, shard: &Self::Record) -> bool {
         match self {
             Self::Func(func_chip) => {
-                let range = shard.get_func_range(func_chip.func.index);
+                let len = shard.queries().func_queries[func_chip.func.index].len();
+                let range = shard.get_func_range(len);
                 !range.is_empty()
             }
             Self::Mem(_mem_chip) => {

--- a/src/lair/toplevel.rs
+++ b/src/lair/toplevel.rs
@@ -542,15 +542,19 @@ impl<F: Field + Ord> CtrlE<F> {
                 let var = get_var(v, ctx)[0];
                 let mut vec = Vec::with_capacity(cases.branches.len());
                 let mut unique_branches = Vec::new();
-                for (fs, block) in cases.branches.iter() {
+                for (i, (fs, block)) in cases.branches.iter().enumerate() {
                     let state = ctx.save_state();
                     let block = block.compile(ctx);
                     ctx.restore_state(state);
-                    fs.iter().for_each(|f| vec.push((*f, block.clone())));
+                    fs.iter().for_each(|f| vec.push((*f, i)));
                     unique_branches.push(block);
                 }
                 let branches = Map::from_vec(vec);
-                let default = cases.default.as_ref().map(|def| def.compile(ctx).into());
+                let default = cases.default.as_ref().map(|def| {
+                    let block = def.compile(ctx);
+                    unique_branches.push(block);
+                    (unique_branches.len() - 1).into()
+                });
                 let cases = Cases { branches, default };
                 Ctrl::Choose(var, cases, unique_branches.into())
             }

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -201,9 +201,10 @@ impl<F: PrimeField32> Ctrl<F> {
                 assert!(ctx.depth_requires.next().is_none());
                 slice.sel[*ident] = F::one();
             }
-            Ctrl::Choose(var, cases, _) => {
+            Ctrl::Choose(var, cases, branches) => {
                 let val = map[*var].0;
-                let branch = cases.match_case(&val).expect("No match");
+                let i = cases.match_case(&val).expect("No match");
+                let branch = &branches[*i];
                 branch.populate_row(ctx, map, index, slice);
             }
             Ctrl::ChooseMany(vars, cases) => {

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -73,7 +73,7 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> FuncChip<'_, F, C1, C2> {
     /// Per-row parallel trace generation
     pub fn generate_trace(&self, shard: &Shard<'_, F>) -> RowMajorMatrix<F> {
         let func_queries = &shard.queries().func_queries()[self.func.index];
-        let range = shard.get_func_range(self.func.index);
+        let range = shard.get_func_range(func_queries.len());
         let width = self.width();
         let non_dummy_height = range.len();
         let height = non_dummy_height.next_power_of_two();
@@ -92,13 +92,7 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> FuncChip<'_, F, C1, C2> {
                 let slice = &mut ColumnMutSlice::from_slice(row, self.layout_sizes);
                 let requires = result.requires.iter();
                 let mut depth_requires = result.depth_requires.iter();
-                let queries = shard.queries();
-                let query_map = &queries.func_queries()[self.func.index];
-                let lookup = query_map
-                    .get(args)
-                    .expect("Cannot find query result")
-                    .provide;
-                let provide = lookup.into_provide();
+                let provide = result.provide.into_provide();
                 result
                     .output
                     .as_ref()
@@ -123,7 +117,7 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> FuncChip<'_, F, C1, C2> {
                     args,
                     index,
                     slice,
-                    queries,
+                    shard.queries(),
                     requires,
                     self.toplevel,
                     result.depth,


### PR DESCRIPTION
Needed refactorization for #372. The changes are:

1) `Ctrl::Choose` will now match field elements onto indices of the list of unique branches (its third argument), instead of matching onto a duplicated branch. Execute and trace generation will now need to match onto the index and use the index to jump to the branch. That also means that the default case is also an index and thus the default branch has been added to the list of unique branches, which simplifies `eval` and `compute_layout_sizes` a bit.
Doing this indirection is only a slight penalty, not really noticeable, and it is basically the same cost as using `Arc`, which is also another layer of indirection (though I believe the indices will be better for cache hits).

2) `generate_trace` has been refactored to remove duplicated work, `get_func_range` has also been refactored slightly

3) I've added the `query_index` to `Record` basically for identification of which coroutine has done the lookup. Nonces are not unique, thus they do not completely identify the caller. Chipset has also included the query index (i.e. which coroutine it is embedded in) so that it properly records the identification. Byte lookups have also included the index.
Note: we could later perhaps parametrize this `query_index` field so that it accounts for whatever metadata is needed. Perhaps shard indices will also become important