### PR TITLE
Allow multiple preloads before entering REPL

### DIFF
--- a/src/core/cli/mod.rs
+++ b/src/core/cli/mod.rs
@@ -16,6 +16,7 @@ use anyhow::{bail, Result};
 use camino::Utf8PathBuf;
 use clap::{Args, Parser, Subcommand};
 use config::{set_config, Config};
+use itertools::Itertools;
 use microchain::MicrochainArgs;
 use repl::Repl;
 
@@ -38,15 +39,15 @@ enum Command {
 
 #[derive(Args, Debug)]
 struct ReplArgs {
-    /// Optional file to be loaded before entering the REPL
-    #[clap(long, value_parser)]
-    preload: Option<Utf8PathBuf>,
+    /// Space separated list of files to load before entering the REPL
+    #[clap(long, value_parser, num_args(1..))]
+    preload: Vec<Utf8PathBuf>,
 }
 
 #[derive(Parser, Debug)]
 struct ReplCli {
-    #[clap(long, value_parser)]
-    preload: Option<Utf8PathBuf>,
+    #[clap(long, value_parser, num_args(1..))]
+    preload: Vec<Utf8PathBuf>,
 }
 
 #[derive(Args, Debug)]
@@ -118,8 +119,8 @@ impl Cli {
 impl ReplCli {
     fn run(&self) -> Result<()> {
         let mut repl = Repl::new_native();
-        if let Some(lurk_file) = &self.preload {
-            repl.load_file(lurk_file, false)?;
+        for lurk_file in self.preload.iter().unique() {
+            repl.load_file(lurk_file, false)?
         }
         repl.run()
     }


### PR DESCRIPTION
extends the `preload` command line option to accept *multiple* files
```
$ lurk repl --help
Enters Lurk's REPL environment ("repl" can be elided)

Usage: lurk repl [OPTIONS]

Options:
      --preload <PRELOAD>...  Space separated list of files to load before entering the REPL
  -h, --help                  Print help
```
* addresses #340 
* files are loaded in sequence without repeats e.g. the following loads `file1` then `file2` then `file3`
```
$ lurk --preload file1 file2 file1 file3
```